### PR TITLE
Phase 3.4 agent memory

### DIFF
--- a/sweet/agents/__init__.py
+++ b/sweet/agents/__init__.py
@@ -4,9 +4,19 @@ This module provides:
 - DataAgent: Orchestrates multi-step data tasks with validation and rollback
 - Recipe: YAML-defined reusable workflow definitions
 - Step / StepResult: Execution units and their outcomes
+- AgentMemory: Persistent context across sessions
 """
 
 from .agent import DataAgent, StepResult
+from .memory import AgentMemory, DatasetFingerprint, RunRecord
 from .recipes import Recipe, RecipeRegistry
 
-__all__ = ["DataAgent", "Recipe", "RecipeRegistry", "StepResult"]
+__all__ = [
+    "AgentMemory",
+    "DataAgent",
+    "DatasetFingerprint",
+    "Recipe",
+    "RecipeRegistry",
+    "RunRecord",
+    "StepResult",
+]

--- a/sweet/agents/agent.py
+++ b/sweet/agents/agent.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any, Callable
 import polars as pl
 
 if TYPE_CHECKING:
+    from .memory import AgentMemory
     from .recipes import Recipe
 
 from ..core.workspace import Workspace
@@ -352,12 +353,14 @@ class DataAgent:
         validate_between_steps: bool = True,
         rollback_on_failure: bool = True,
         checkpoint_fn: Callable[[Checkpoint], CheckpointAction] | None = None,
+        memory: AgentMemory | None = None,
     ) -> None:
         self.workspace = workspace
         self.validate_between_steps = validate_between_steps
         self.rollback_on_failure = rollback_on_failure
         self._checkpoint_fn = checkpoint_fn
         self._custom_steps: dict[str, StepFn] = {}
+        self.memory = memory
 
     def register_step(self, name: str, fn: StepFn) -> None:
         """Register a custom step function.
@@ -549,6 +552,10 @@ class DataAgent:
 
         result.summary = " ".join(parts)
 
+        # Record run in memory if available
+        if self.memory is not None:
+            self._record_to_memory(result, steps, recipe_name=None)
+
         return result
 
     def run_recipe(self, recipe: "Recipe", **params: Any) -> AgentResult:
@@ -568,10 +575,16 @@ class DataAgent:
         # (Currently params are informational — step functions read from workspace)
         _ = resolved_params
 
-        return self.run_steps(
+        result = self.run_steps(
             recipe.steps,
             checkpoint_before=recipe.checkpoints,
         )
+
+        # Record with recipe name
+        if self.memory is not None:
+            self._record_to_memory(result, recipe.steps, recipe_name=recipe.name)
+
+        return result
 
     def _handle_checkpoint(self, checkpoint: Checkpoint) -> CheckpointAction:
         """Handle a checkpoint pause point."""
@@ -579,3 +592,44 @@ class DataAgent:
             return self._checkpoint_fn(checkpoint)
         # Default: continue without pausing
         return CheckpointAction.CONTINUE
+
+    def _record_to_memory(
+        self,
+        result: AgentResult,
+        steps: list[str | StepFn],
+        recipe_name: str | None,
+    ) -> None:
+        """Record a completed run to memory."""
+        from .memory import AgentMemory, RunRecord
+
+        fingerprint = AgentMemory.fingerprint_workspace(self.workspace)
+        step_names = [
+            s if isinstance(s, str) else getattr(s, "__name__", "custom")
+            for s in steps
+        ]
+
+        record = RunRecord(
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            recipe_name=recipe_name,
+            steps=step_names,
+            dataset_fingerprint=fingerprint,
+            success=result.success,
+            n_passed=result.n_passed,
+            n_failed=result.n_failed,
+            n_rolled_back=result.n_rolled_back,
+            duration_s=result.total_duration_s,
+        )
+        self.memory.record_run(record)
+
+    def suggest_recipe(self) -> str | None:
+        """Suggest a recipe based on memory of similar datasets.
+
+        Returns:
+            Recipe name that previously succeeded on similar data, or None.
+        """
+        if self.memory is None:
+            return None
+        from .memory import AgentMemory
+
+        fingerprint = AgentMemory.fingerprint_workspace(self.workspace)
+        return self.memory.suggest_recipe(fingerprint)

--- a/sweet/agents/memory.py
+++ b/sweet/agents/memory.py
@@ -1,0 +1,351 @@
+"""Agent Memory: Persistent context for Sweet agents.
+
+Agents remember context across sessions:
+- Data context: What datasets have been loaded, their schemas, past transforms
+- User preferences: Preferred date formats, naming conventions, quality thresholds
+- Domain knowledge: Business rules, valid value ranges, known relationships
+- History: What worked before on similar data (successful recipes, common patterns)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+DEFAULT_MEMORY_DIR = Path.home() / ".sweet" / "memory"
+
+
+@dataclass
+class DatasetFingerprint:
+    """A lightweight fingerprint of a dataset for matching similar data later."""
+
+    columns: list[str]
+    dtypes: dict[str, str]
+    row_count: int
+    column_count: int
+    file_name: str | None = None
+    content_hash: str | None = None
+
+    def similarity(self, other: DatasetFingerprint) -> float:
+        """Compute similarity score (0.0–1.0) between two fingerprints."""
+        if not self.columns or not other.columns:
+            return 0.0
+
+        # Jaccard similarity on column names
+        set_a = set(self.columns)
+        set_b = set(other.columns)
+        if not set_a and not set_b:
+            return 0.0
+        jaccard = len(set_a & set_b) / len(set_a | set_b)
+
+        # Dtype overlap for shared columns
+        shared = set_a & set_b
+        if shared:
+            dtype_match = sum(
+                1 for c in shared if self.dtypes.get(c) == other.dtypes.get(c)
+            ) / len(shared)
+        else:
+            dtype_match = 0.0
+
+        return 0.6 * jaccard + 0.4 * dtype_match
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "columns": self.columns,
+            "dtypes": self.dtypes,
+            "row_count": self.row_count,
+            "column_count": self.column_count,
+            "file_name": self.file_name,
+            "content_hash": self.content_hash,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> DatasetFingerprint:
+        return cls(
+            columns=d["columns"],
+            dtypes=d["dtypes"],
+            row_count=d["row_count"],
+            column_count=d["column_count"],
+            file_name=d.get("file_name"),
+            content_hash=d.get("content_hash"),
+        )
+
+
+@dataclass
+class RunRecord:
+    """Record of a completed agent run."""
+
+    timestamp: str
+    recipe_name: str | None
+    steps: list[str]
+    dataset_fingerprint: DatasetFingerprint
+    success: bool
+    n_passed: int
+    n_failed: int
+    n_rolled_back: int
+    duration_s: float
+    notes: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "timestamp": self.timestamp,
+            "recipe_name": self.recipe_name,
+            "steps": self.steps,
+            "dataset_fingerprint": self.dataset_fingerprint.to_dict(),
+            "success": self.success,
+            "n_passed": self.n_passed,
+            "n_failed": self.n_failed,
+            "n_rolled_back": self.n_rolled_back,
+            "duration_s": self.duration_s,
+            "notes": self.notes,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> RunRecord:
+        return cls(
+            timestamp=d["timestamp"],
+            recipe_name=d.get("recipe_name"),
+            steps=d["steps"],
+            dataset_fingerprint=DatasetFingerprint.from_dict(d["dataset_fingerprint"]),
+            success=d["success"],
+            n_passed=d["n_passed"],
+            n_failed=d["n_failed"],
+            n_rolled_back=d["n_rolled_back"],
+            duration_s=d["duration_s"],
+            notes=d.get("notes"),
+        )
+
+
+@dataclass
+class AgentMemory:
+    """Persistent memory store for Sweet agents.
+
+    Stores:
+    - User preferences (date formats, naming conventions, thresholds)
+    - Domain knowledge (business rules, valid ranges)
+    - Run history (what recipes/steps worked on what data)
+    - Dataset fingerprints (for finding similar past work)
+
+    Memory persists to disk as JSON files in ~/.sweet/memory/ by default.
+    """
+
+    preferences: dict[str, Any] = field(default_factory=dict)
+    domain_rules: dict[str, Any] = field(default_factory=dict)
+    run_history: list[RunRecord] = field(default_factory=list)
+    _memory_dir: Path = field(default_factory=lambda: DEFAULT_MEMORY_DIR)
+
+    def __post_init__(self) -> None:
+        self._memory_dir.mkdir(parents=True, exist_ok=True)
+
+    @classmethod
+    def load(cls, memory_dir: Path | None = None) -> AgentMemory:
+        """Load memory from disk.
+
+        Args:
+            memory_dir: Directory to load from. Defaults to ~/.sweet/memory/.
+
+        Returns:
+            AgentMemory instance with loaded state.
+        """
+        directory = memory_dir or DEFAULT_MEMORY_DIR
+        directory.mkdir(parents=True, exist_ok=True)
+
+        preferences = {}
+        domain_rules = {}
+        run_history: list[RunRecord] = []
+
+        prefs_file = directory / "preferences.json"
+        if prefs_file.exists():
+            preferences = json.loads(prefs_file.read_text())
+
+        rules_file = directory / "domain_rules.json"
+        if rules_file.exists():
+            domain_rules = json.loads(rules_file.read_text())
+
+        history_file = directory / "run_history.json"
+        if history_file.exists():
+            records = json.loads(history_file.read_text())
+            run_history = [RunRecord.from_dict(r) for r in records]
+
+        return cls(
+            preferences=preferences,
+            domain_rules=domain_rules,
+            run_history=run_history,
+            _memory_dir=directory,
+        )
+
+    def save(self) -> None:
+        """Persist all memory to disk."""
+        self._memory_dir.mkdir(parents=True, exist_ok=True)
+
+        prefs_file = self._memory_dir / "preferences.json"
+        prefs_file.write_text(json.dumps(self.preferences, indent=2))
+
+        rules_file = self._memory_dir / "domain_rules.json"
+        rules_file.write_text(json.dumps(self.domain_rules, indent=2))
+
+        history_file = self._memory_dir / "run_history.json"
+        history_file.write_text(
+            json.dumps([r.to_dict() for r in self.run_history], indent=2)
+        )
+
+    # -------------------------------------------------------------------------
+    # Preferences
+    # -------------------------------------------------------------------------
+
+    def set_preference(self, key: str, value: Any) -> None:
+        """Set a user preference.
+
+        Args:
+            key: Preference key (e.g., "date_format", "null_handling").
+            value: Preference value.
+        """
+        self.preferences[key] = value
+
+    def get_preference(self, key: str, default: Any = None) -> Any:
+        """Get a user preference.
+
+        Args:
+            key: Preference key.
+            default: Default value if not set.
+
+        Returns:
+            The preference value or the default.
+        """
+        return self.preferences.get(key, default)
+
+    # -------------------------------------------------------------------------
+    # Domain Rules
+    # -------------------------------------------------------------------------
+
+    def add_rule(self, name: str, rule: dict[str, Any]) -> None:
+        """Add a domain rule.
+
+        Args:
+            name: Rule name (e.g., "revenue_positive", "valid_countries").
+            rule: Rule definition dict (column, check, severity, etc.).
+        """
+        self.domain_rules[name] = rule
+
+    def get_rule(self, name: str) -> dict[str, Any] | None:
+        """Get a domain rule by name."""
+        return self.domain_rules.get(name)
+
+    def list_rules(self) -> list[dict[str, Any]]:
+        """List all domain rules."""
+        return [{"name": k, **v} for k, v in self.domain_rules.items()]
+
+    # -------------------------------------------------------------------------
+    # Run History
+    # -------------------------------------------------------------------------
+
+    def record_run(self, record: RunRecord) -> None:
+        """Record a completed agent run.
+
+        Args:
+            record: The RunRecord to store.
+        """
+        self.run_history.append(record)
+        # Keep at most 500 records
+        if len(self.run_history) > 500:
+            self.run_history = self.run_history[-500:]
+
+    def find_similar_runs(
+        self, fingerprint: DatasetFingerprint, threshold: float = 0.5, limit: int = 5
+    ) -> list[RunRecord]:
+        """Find past runs on similar datasets.
+
+        Args:
+            fingerprint: The current dataset's fingerprint.
+            threshold: Minimum similarity score (0.0–1.0).
+            limit: Maximum number of results.
+
+        Returns:
+            List of RunRecords for similar datasets, most recent first.
+        """
+        scored = []
+        for record in reversed(self.run_history):
+            score = fingerprint.similarity(record.dataset_fingerprint)
+            if score >= threshold:
+                scored.append((score, record))
+
+        scored.sort(key=lambda x: x[0], reverse=True)
+        return [record for _, record in scored[:limit]]
+
+    def suggest_recipe(self, fingerprint: DatasetFingerprint) -> str | None:
+        """Suggest a recipe based on what worked on similar data before.
+
+        Args:
+            fingerprint: Current dataset fingerprint.
+
+        Returns:
+            Recipe name that succeeded on similar data, or None.
+        """
+        similar = self.find_similar_runs(fingerprint, threshold=0.6)
+        # Find most common successful recipe
+        recipe_counts: dict[str, int] = {}
+        for record in similar:
+            if record.success and record.recipe_name:
+                recipe_counts[record.recipe_name] = recipe_counts.get(record.recipe_name, 0) + 1
+
+        if not recipe_counts:
+            return None
+        return max(recipe_counts, key=recipe_counts.get)  # type: ignore[arg-type]
+
+    # -------------------------------------------------------------------------
+    # Dataset Fingerprinting
+    # -------------------------------------------------------------------------
+
+    @staticmethod
+    def fingerprint_workspace(workspace: Any) -> DatasetFingerprint:
+        """Create a fingerprint of the current workspace data.
+
+        Args:
+            workspace: A Workspace instance.
+
+        Returns:
+            DatasetFingerprint for the current data.
+        """
+        df = workspace.df
+        if df is None:
+            return DatasetFingerprint(
+                columns=[], dtypes={}, row_count=0, column_count=0
+            )
+
+        # Compute a content hash from first/last few rows + schema
+        schema_str = str(sorted(df.schema.items()))
+        sample_str = str(df.head(5).to_dicts()) + str(df.tail(5).to_dicts())
+        content_hash = hashlib.sha256(
+            (schema_str + sample_str).encode()
+        ).hexdigest()[:16]
+
+        return DatasetFingerprint(
+            columns=df.columns,
+            dtypes={col: str(dtype) for col, dtype in df.schema.items()},
+            row_count=df.height,
+            column_count=df.width,
+            file_name=getattr(workspace, "_source_file", None),
+            content_hash=content_hash,
+        )
+
+    # -------------------------------------------------------------------------
+    # Summary
+    # -------------------------------------------------------------------------
+
+    def summary(self) -> dict[str, Any]:
+        """Get a summary of memory contents.
+
+        Returns:
+            Dict with counts of preferences, rules, and history records.
+        """
+        successful_runs = sum(1 for r in self.run_history if r.success)
+        return {
+            "n_preferences": len(self.preferences),
+            "n_domain_rules": len(self.domain_rules),
+            "n_run_records": len(self.run_history),
+            "n_successful_runs": successful_runs,
+            "memory_dir": str(self._memory_dir),
+        }

--- a/sweet/cli.py
+++ b/sweet/cli.py
@@ -647,5 +647,147 @@ def serve(protocol: str, port: int | None):
         raise SystemExit(1)
 
 
+# =============================================================================
+# Memory commands
+# =============================================================================
+
+
+@main.group()
+def memory():
+    """Manage agent memory (preferences, domain rules, run history)."""
+    pass
+
+
+@memory.command("show")
+def memory_show():
+    """Show a summary of what the agent remembers.
+
+    Example:
+        sweet memory show
+    """
+    from .agents import AgentMemory
+
+    mem = AgentMemory.load()
+    info = mem.summary()
+    click.echo(f"\n  Agent Memory ({info['memory_dir']})\n")
+    click.echo(f"    Preferences:  {info['n_preferences']}")
+    click.echo(f"    Domain rules: {info['n_domain_rules']}")
+    click.echo(f"    Run history:  {info['n_run_records']} ({info['n_successful_runs']} successful)")
+    click.echo()
+
+
+@memory.command("preferences")
+def memory_preferences():
+    """List all stored preferences.
+
+    Example:
+        sweet memory preferences
+    """
+    from .agents import AgentMemory
+
+    mem = AgentMemory.load()
+    if not mem.preferences:
+        click.echo("\n  No preferences stored.\n")
+        return
+    click.echo("\n  Preferences:\n")
+    for key, value in sorted(mem.preferences.items()):
+        click.echo(f"    {key}: {value}")
+    click.echo()
+
+
+@memory.command("set")
+@click.argument("key")
+@click.argument("value")
+def memory_set(key: str, value: str):
+    """Set a preference (key-value pair).
+
+    Example:
+        sweet memory set date_format ISO-8601
+        sweet memory set null_handling explicit
+    """
+    import json as json_mod
+
+    from .agents import AgentMemory
+
+    mem = AgentMemory.load()
+    # Try to parse as JSON for booleans, numbers, objects
+    try:
+        parsed = json_mod.loads(value)
+    except (json_mod.JSONDecodeError, ValueError):
+        parsed = value
+    mem.set_preference(key, parsed)
+    mem.save()
+    click.echo(f"  ✓ Set '{key}' = {parsed}")
+
+
+@memory.command("rules")
+def memory_rules():
+    """List all domain rules.
+
+    Example:
+        sweet memory rules
+    """
+    from .agents import AgentMemory
+
+    mem = AgentMemory.load()
+    rules = mem.list_rules()
+    if not rules:
+        click.echo("\n  No domain rules stored.\n")
+        return
+    click.echo("\n  Domain Rules:\n")
+    for rule in rules:
+        name = rule.pop("name")
+        click.echo(f"    {name}: {rule}")
+    click.echo()
+
+
+@memory.command("history")
+@click.option("--limit", "-n", default=10, help="Number of records to show")
+def memory_history(limit: int):
+    """Show recent agent run history.
+
+    Example:
+        sweet memory history
+        sweet memory history -n 20
+    """
+    from .agents import AgentMemory
+
+    mem = AgentMemory.load()
+    if not mem.run_history:
+        click.echo("\n  No run history recorded.\n")
+        return
+    recent = mem.run_history[-limit:]
+    click.echo(f"\n  Recent runs (last {len(recent)}):\n")
+    for record in reversed(recent):
+        icon = "✓" if record.success else "✗"
+        recipe_info = f" ({record.recipe_name})" if record.recipe_name else ""
+        click.echo(
+            f"    {icon} {record.timestamp[:19]}{recipe_info} "
+            f"— {record.n_passed} passed, {record.n_failed} failed "
+            f"[{record.duration_s:.2f}s]"
+        )
+    click.echo()
+
+
+@memory.command("clear")
+@click.option("--confirm", is_flag=True, help="Skip confirmation prompt")
+def memory_clear(confirm: bool):
+    """Clear all agent memory.
+
+    Example:
+        sweet memory clear --confirm
+    """
+    from .agents import AgentMemory
+
+    if not confirm:
+        click.confirm("  Clear all agent memory? This cannot be undone", abort=True)
+    mem = AgentMemory.load()
+    mem.preferences = {}
+    mem.domain_rules = {}
+    mem.run_history = []
+    mem.save()
+    click.echo("  ✓ Agent memory cleared.")
+
+
 if __name__ == "__main__":
     main()

--- a/sweet/mcp.py
+++ b/sweet/mcp.py
@@ -534,6 +534,78 @@ async def list_tools() -> list[Tool]:
             description="List all available recipes with their descriptions and steps.",
             inputSchema={"type": "object", "properties": {}},
         ),
+        Tool(
+            name="sweet_memory_summary",
+            description="Get a summary of the agent's persistent memory (preferences, domain rules, run history).",
+            inputSchema={"type": "object", "properties": {}},
+        ),
+        Tool(
+            name="sweet_memory_get_preferences",
+            description="Get all stored user preferences.",
+            inputSchema={"type": "object", "properties": {}},
+        ),
+        Tool(
+            name="sweet_memory_set_preference",
+            description="Set a user preference that persists across sessions.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "key": {
+                        "type": "string",
+                        "description": "Preference key (e.g., 'date_format', 'null_handling', 'naming_convention').",
+                    },
+                    "value": {
+                        "description": "Preference value (string, number, boolean, or object).",
+                    },
+                },
+                "required": ["key", "value"],
+            },
+        ),
+        Tool(
+            name="sweet_memory_add_rule",
+            description="Add a domain rule to memory (business rules, valid value ranges, constraints).",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Rule name (e.g., 'revenue_positive', 'valid_countries').",
+                    },
+                    "rule": {
+                        "type": "object",
+                        "description": "Rule definition with fields like column, check, severity, description.",
+                    },
+                },
+                "required": ["name", "rule"],
+            },
+        ),
+        Tool(
+            name="sweet_memory_list_rules",
+            description="List all domain rules stored in memory.",
+            inputSchema={"type": "object", "properties": {}},
+        ),
+        Tool(
+            name="sweet_memory_suggest_recipe",
+            description="Suggest a recipe based on memory of what worked on similar datasets before.",
+            inputSchema={"type": "object", "properties": {}},
+        ),
+        Tool(
+            name="sweet_memory_find_similar_runs",
+            description="Find past agent runs on datasets similar to the currently loaded data.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "threshold": {
+                        "type": "number",
+                        "description": "Minimum similarity score (0.0–1.0). Default: 0.5.",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Max results to return. Default: 5.",
+                    },
+                },
+            },
+        ),
     ]
 
 
@@ -902,6 +974,100 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
                 TextContent(
                     type="text",
                     text=json.dumps(recipes, indent=2, default=str),
+                )
+            ]
+
+        elif name == "sweet_memory_summary":
+            from .agents import AgentMemory
+
+            memory = AgentMemory.load()
+            return [
+                TextContent(
+                    type="text",
+                    text=json.dumps(memory.summary(), indent=2, default=str),
+                )
+            ]
+
+        elif name == "sweet_memory_get_preferences":
+            from .agents import AgentMemory
+
+            memory = AgentMemory.load()
+            return [
+                TextContent(
+                    type="text",
+                    text=json.dumps(memory.preferences, indent=2, default=str),
+                )
+            ]
+
+        elif name == "sweet_memory_set_preference":
+            from .agents import AgentMemory
+
+            memory = AgentMemory.load()
+            memory.set_preference(arguments["key"], arguments["value"])
+            memory.save()
+            return [
+                TextContent(
+                    type="text",
+                    text=f"Preference '{arguments['key']}' set to: {arguments['value']}",
+                )
+            ]
+
+        elif name == "sweet_memory_add_rule":
+            from .agents import AgentMemory
+
+            memory = AgentMemory.load()
+            memory.add_rule(arguments["name"], arguments["rule"])
+            memory.save()
+            return [
+                TextContent(
+                    type="text",
+                    text=f"Domain rule '{arguments['name']}' added.",
+                )
+            ]
+
+        elif name == "sweet_memory_list_rules":
+            from .agents import AgentMemory
+
+            memory = AgentMemory.load()
+            return [
+                TextContent(
+                    type="text",
+                    text=json.dumps(memory.list_rules(), indent=2, default=str),
+                )
+            ]
+
+        elif name == "sweet_memory_suggest_recipe":
+            from .agents import AgentMemory
+
+            memory = AgentMemory.load()
+            fingerprint = AgentMemory.fingerprint_workspace(ws)
+            suggestion = memory.suggest_recipe(fingerprint)
+            if suggestion:
+                return [
+                    TextContent(
+                        type="text",
+                        text=f"Suggested recipe: {suggestion} (based on past success with similar data)",
+                    )
+                ]
+            return [
+                TextContent(
+                    type="text",
+                    text="No recipe suggestion available — no similar past runs found.",
+                )
+            ]
+
+        elif name == "sweet_memory_find_similar_runs":
+            from .agents import AgentMemory
+
+            memory = AgentMemory.load()
+            fingerprint = AgentMemory.fingerprint_workspace(ws)
+            threshold = arguments.get("threshold", 0.5)
+            limit = arguments.get("limit", 5)
+            similar = memory.find_similar_runs(fingerprint, threshold=threshold, limit=limit)
+            return [
+                TextContent(
+                    type="text",
+                    text=json.dumps([r.to_dict() for r in similar], indent=2, default=str),
                 )
             ]
 

--- a/tests/test_agent_memory.py
+++ b/tests/test_agent_memory.py
@@ -1,0 +1,374 @@
+"""Tests for Agent Memory: preferences, domain rules, run history, and suggestions."""
+
+import json
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from sweet.agents import AgentMemory, DataAgent, RecipeRegistry
+from sweet.agents.memory import DatasetFingerprint, RunRecord
+from sweet.core.workspace import Workspace
+
+
+# =============================================================================
+# DatasetFingerprint
+# =============================================================================
+
+
+class TestDatasetFingerprint:
+    """Tests for dataset fingerprinting and similarity."""
+
+    def test_fingerprint_from_workspace(self):
+        """Create fingerprint from a workspace."""
+        ws = Workspace()
+        ws.load_df(pl.DataFrame({"x": [1, 2, 3], "name": ["a", "b", "c"]}))
+
+        fp = AgentMemory.fingerprint_workspace(ws)
+
+        assert fp.columns == ["x", "name"]
+        assert fp.row_count == 3
+        assert fp.column_count == 2
+        assert "x" in fp.dtypes
+        assert fp.content_hash is not None
+
+    def test_fingerprint_empty_workspace(self):
+        """Fingerprint of empty workspace."""
+        ws = Workspace()
+
+        fp = AgentMemory.fingerprint_workspace(ws)
+
+        assert fp.columns == []
+        assert fp.row_count == 0
+
+    def test_similarity_identical(self):
+        """Identical fingerprints have similarity 1.0."""
+        fp = DatasetFingerprint(
+            columns=["x", "y", "z"],
+            dtypes={"x": "Int64", "y": "Utf8", "z": "Float64"},
+            row_count=100,
+            column_count=3,
+        )
+        assert fp.similarity(fp) == 1.0
+
+    def test_similarity_no_overlap(self):
+        """No shared columns → similarity 0."""
+        fp1 = DatasetFingerprint(
+            columns=["a", "b"],
+            dtypes={"a": "Int64", "b": "Utf8"},
+            row_count=10,
+            column_count=2,
+        )
+        fp2 = DatasetFingerprint(
+            columns=["x", "y"],
+            dtypes={"x": "Int64", "y": "Utf8"},
+            row_count=10,
+            column_count=2,
+        )
+        assert fp1.similarity(fp2) == 0.0
+
+    def test_similarity_partial_overlap(self):
+        """Partial column overlap gives intermediate similarity."""
+        fp1 = DatasetFingerprint(
+            columns=["x", "y", "z"],
+            dtypes={"x": "Int64", "y": "Utf8", "z": "Float64"},
+            row_count=100,
+            column_count=3,
+        )
+        fp2 = DatasetFingerprint(
+            columns=["x", "y", "w"],
+            dtypes={"x": "Int64", "y": "Utf8", "w": "Boolean"},
+            row_count=50,
+            column_count=3,
+        )
+        score = fp1.similarity(fp2)
+        assert 0.3 < score < 0.9  # Partial match
+
+    def test_similarity_same_columns_different_types(self):
+        """Same columns but different types → lower similarity."""
+        fp1 = DatasetFingerprint(
+            columns=["x", "y"],
+            dtypes={"x": "Int64", "y": "Utf8"},
+            row_count=10,
+            column_count=2,
+        )
+        fp2 = DatasetFingerprint(
+            columns=["x", "y"],
+            dtypes={"x": "Utf8", "y": "Float64"},
+            row_count=10,
+            column_count=2,
+        )
+        score = fp1.similarity(fp2)
+        # Same columns (jaccard=1.0) but types don't match (dtype_match=0)
+        assert score == pytest.approx(0.6)
+
+    def test_fingerprint_roundtrip(self):
+        """Fingerprint serializes and deserializes."""
+        fp = DatasetFingerprint(
+            columns=["a", "b"],
+            dtypes={"a": "Int64", "b": "Utf8"},
+            row_count=42,
+            column_count=2,
+            file_name="test.csv",
+            content_hash="abc123",
+        )
+        d = fp.to_dict()
+        fp2 = DatasetFingerprint.from_dict(d)
+        assert fp2.columns == fp.columns
+        assert fp2.content_hash == fp.content_hash
+
+
+# =============================================================================
+# AgentMemory — Preferences
+# =============================================================================
+
+
+class TestAgentMemoryPreferences:
+    """Tests for preference storage."""
+
+    def test_set_and_get(self, tmp_path):
+        """Set and get a preference."""
+        mem = AgentMemory(_memory_dir=tmp_path)
+        mem.set_preference("date_format", "ISO-8601")
+
+        assert mem.get_preference("date_format") == "ISO-8601"
+
+    def test_get_default(self, tmp_path):
+        """Get with default for missing key."""
+        mem = AgentMemory(_memory_dir=tmp_path)
+        assert mem.get_preference("missing", "fallback") == "fallback"
+
+    def test_persistence(self, tmp_path):
+        """Preferences persist across load/save cycles."""
+        mem = AgentMemory(_memory_dir=tmp_path)
+        mem.set_preference("naming", "snake_case")
+        mem.save()
+
+        mem2 = AgentMemory.load(memory_dir=tmp_path)
+        assert mem2.get_preference("naming") == "snake_case"
+
+
+# =============================================================================
+# AgentMemory — Domain Rules
+# =============================================================================
+
+
+class TestAgentMemoryRules:
+    """Tests for domain rule storage."""
+
+    def test_add_and_get_rule(self, tmp_path):
+        """Add and retrieve a domain rule."""
+        mem = AgentMemory(_memory_dir=tmp_path)
+        mem.add_rule("revenue_positive", {"column": "revenue", "check": "> 0", "severity": "error"})
+
+        rule = mem.get_rule("revenue_positive")
+        assert rule is not None
+        assert rule["column"] == "revenue"
+
+    def test_list_rules(self, tmp_path):
+        """List all rules."""
+        mem = AgentMemory(_memory_dir=tmp_path)
+        mem.add_rule("r1", {"check": "x > 0"})
+        mem.add_rule("r2", {"check": "y is not null"})
+
+        rules = mem.list_rules()
+        assert len(rules) == 2
+        names = [r["name"] for r in rules]
+        assert "r1" in names
+        assert "r2" in names
+
+    def test_rules_persist(self, tmp_path):
+        """Rules persist across save/load."""
+        mem = AgentMemory(_memory_dir=tmp_path)
+        mem.add_rule("test_rule", {"severity": "warning"})
+        mem.save()
+
+        mem2 = AgentMemory.load(memory_dir=tmp_path)
+        assert mem2.get_rule("test_rule") is not None
+
+
+# =============================================================================
+# AgentMemory — Run History
+# =============================================================================
+
+
+class TestAgentMemoryHistory:
+    """Tests for run history recording and querying."""
+
+    def _make_record(self, success=True, recipe=None, columns=None):
+        """Helper to create a RunRecord."""
+        return RunRecord(
+            timestamp="2026-05-16T10:00:00+00:00",
+            recipe_name=recipe,
+            steps=["validate"],
+            dataset_fingerprint=DatasetFingerprint(
+                columns=columns or ["x", "y"],
+                dtypes={"x": "Int64", "y": "Utf8"},
+                row_count=100,
+                column_count=2,
+            ),
+            success=success,
+            n_passed=1,
+            n_failed=0,
+            n_rolled_back=0,
+            duration_s=0.5,
+        )
+
+    def test_record_run(self, tmp_path):
+        """Record a run."""
+        mem = AgentMemory(_memory_dir=tmp_path)
+        record = self._make_record()
+        mem.record_run(record)
+
+        assert len(mem.run_history) == 1
+
+    def test_history_cap(self, tmp_path):
+        """History is capped at 500 records."""
+        mem = AgentMemory(_memory_dir=tmp_path)
+        for i in range(510):
+            mem.record_run(self._make_record())
+
+        assert len(mem.run_history) == 500
+
+    def test_find_similar_runs(self, tmp_path):
+        """Find runs on similar datasets."""
+        mem = AgentMemory(_memory_dir=tmp_path)
+        mem.record_run(self._make_record(columns=["x", "y"]))
+        mem.record_run(self._make_record(columns=["a", "b", "c"]))
+
+        fp = DatasetFingerprint(
+            columns=["x", "y"],
+            dtypes={"x": "Int64", "y": "Utf8"},
+            row_count=50,
+            column_count=2,
+        )
+        similar = mem.find_similar_runs(fp, threshold=0.5)
+        assert len(similar) == 1
+
+    def test_suggest_recipe(self, tmp_path):
+        """Suggest recipe from successful past runs."""
+        mem = AgentMemory(_memory_dir=tmp_path)
+        mem.record_run(self._make_record(success=True, recipe="clean-csv", columns=["x", "y"]))
+        mem.record_run(self._make_record(success=True, recipe="clean-csv", columns=["x", "y"]))
+        mem.record_run(self._make_record(success=True, recipe="quality-check", columns=["x", "y"]))
+
+        fp = DatasetFingerprint(
+            columns=["x", "y"],
+            dtypes={"x": "Int64", "y": "Utf8"},
+            row_count=50,
+            column_count=2,
+        )
+        suggestion = mem.suggest_recipe(fp)
+        assert suggestion == "clean-csv"
+
+    def test_suggest_recipe_no_history(self, tmp_path):
+        """No suggestion when no history."""
+        mem = AgentMemory(_memory_dir=tmp_path)
+        fp = DatasetFingerprint(columns=["x"], dtypes={"x": "Int64"}, row_count=10, column_count=1)
+        assert mem.suggest_recipe(fp) is None
+
+    def test_history_persistence(self, tmp_path):
+        """History persists across save/load."""
+        mem = AgentMemory(_memory_dir=tmp_path)
+        mem.record_run(self._make_record(recipe="test-recipe"))
+        mem.save()
+
+        mem2 = AgentMemory.load(memory_dir=tmp_path)
+        assert len(mem2.run_history) == 1
+        assert mem2.run_history[0].recipe_name == "test-recipe"
+
+
+# =============================================================================
+# AgentMemory — Summary
+# =============================================================================
+
+
+class TestAgentMemorySummary:
+    """Tests for summary output."""
+
+    def test_summary(self, tmp_path):
+        """Summary returns correct counts."""
+        mem = AgentMemory(_memory_dir=tmp_path)
+        mem.set_preference("a", 1)
+        mem.set_preference("b", 2)
+        mem.add_rule("r1", {"check": "x > 0"})
+
+        info = mem.summary()
+        assert info["n_preferences"] == 2
+        assert info["n_domain_rules"] == 1
+        assert info["n_run_records"] == 0
+        assert info["n_successful_runs"] == 0
+
+
+# =============================================================================
+# DataAgent + Memory Integration
+# =============================================================================
+
+
+class TestDataAgentMemoryIntegration:
+    """Integration tests for DataAgent with memory."""
+
+    def test_agent_records_to_memory(self, tmp_path):
+        """DataAgent automatically records runs to memory."""
+        mem = AgentMemory(_memory_dir=tmp_path)
+        ws = Workspace()
+        ws.load_df(pl.DataFrame({"x": [1, 2, 3]}))
+
+        agent = DataAgent(workspace=ws, memory=mem, validate_between_steps=False)
+        agent.run_steps(["validate"])
+
+        assert len(mem.run_history) == 1
+        assert mem.run_history[0].success is True
+        assert mem.run_history[0].steps == ["validate"]
+
+    def test_agent_records_recipe_name(self, tmp_path):
+        """DataAgent records recipe name when running a recipe."""
+        mem = AgentMemory(_memory_dir=tmp_path)
+        ws = Workspace()
+        ws.load_df(pl.DataFrame({"x": [1, 2, 3]}))
+
+        registry = RecipeRegistry()
+        recipe = registry.get("quality-check")
+
+        agent = DataAgent(workspace=ws, memory=mem)
+        agent.run_recipe(recipe)
+
+        assert len(mem.run_history) >= 1
+        # The recipe run is recorded (run_recipe calls run_steps which also records,
+        # plus run_recipe records again — find the one with recipe_name)
+        recipe_records = [r for r in mem.run_history if r.recipe_name is not None]
+        assert len(recipe_records) >= 1
+        assert recipe_records[0].recipe_name == "Data Quality Check"
+
+    def test_agent_suggest_recipe_from_memory(self, tmp_path):
+        """Agent suggests recipes based on memory."""
+        mem = AgentMemory(_memory_dir=tmp_path)
+
+        # First run: record a successful recipe
+        ws1 = Workspace()
+        ws1.load_df(pl.DataFrame({"val": [1, 2, 3], "label": ["a", "b", "c"]}))
+        agent1 = DataAgent(workspace=ws1, memory=mem, validate_between_steps=False)
+
+        registry = RecipeRegistry()
+        recipe = registry.get("quality-check")
+        agent1.run_recipe(recipe)
+        mem.save()
+
+        # Second run: similar data → should suggest same recipe
+        ws2 = Workspace()
+        ws2.load_df(pl.DataFrame({"val": [10, 20], "label": ["x", "y"]}))
+        agent2 = DataAgent(workspace=ws2, memory=mem, validate_between_steps=False)
+
+        suggestion = agent2.suggest_recipe()
+        assert suggestion == "Data Quality Check"
+
+    def test_agent_without_memory_no_error(self):
+        """DataAgent works fine without memory."""
+        ws = Workspace()
+        ws.load_df(pl.DataFrame({"x": [1, 2, 3]}))
+
+        agent = DataAgent(workspace=ws, validate_between_steps=False)
+        result = agent.run_steps(["validate"])
+
+        assert result.success is True
+        assert agent.suggest_recipe() is None


### PR DESCRIPTION
This PR introduces a persistent memory system for Sweet agents, enabling them to remember user preferences, domain rules, and run history across sessions. It adds a new `AgentMemory` module, integrates memory features into the agent workflow, and exposes memory management commands via both the CLI and the agent's tool interface.
l