### PR TITLE
Phase 4.2

### DIFF
--- a/sweet/cli.py
+++ b/sweet/cli.py
@@ -114,6 +114,38 @@ def load(source: str, name: str | None, fmt: str | None, query: str | None, tabl
 
 
 @main.command()
+@click.argument("source", type=click.Path(exists=True))
+@click.argument("dest")
+@click.option(
+    "--format", "-f", "fmt", type=str, default=None,
+    help="Force export format (csv, parquet, json, tsv, ndjson, ipc)."
+)
+@click.option("--table", type=str, default=None, help="Table name (for database destinations).")
+@click.option(
+    "--mode", type=click.Choice(["replace", "append", "fail"]), default="replace",
+    help="Write mode for databases."
+)
+def export(source: str, dest: str, fmt: str | None, table: str | None, mode: str):
+    """Export data to a file, database, or cloud storage.
+
+    Load SOURCE, then export to DEST. DEST can be a file path, cloud URL
+    (s3://, gs://), or database connection string.
+
+    Examples:
+        sweet export data.csv output.parquet
+        sweet export data.csv s3://bucket/path/data.parquet
+        sweet export data.csv "sqlite:///my.db" --table results
+        sweet export data.csv output.tsv --format tsv
+    """
+    from .core.workspace import Workspace
+
+    ws = Workspace()
+    ws.load(source)
+    ws.export(dest, format=fmt, table=table, mode=mode)
+    click.echo(f"  ✓ Exported {ws.shape[0]} rows × {ws.shape[1]} cols to: {dest}")
+
+
+@main.command()
 @click.argument("file", type=click.Path(exists=True))
 @click.option("--transform", "-t", multiple=True, help="Polars expression(s) to apply")
 @click.option("--export", "-e", "export_path", type=click.Path(), help="Export result to file")

--- a/sweet/core/exporters.py
+++ b/sweet/core/exporters.py
@@ -1,0 +1,312 @@
+"""Export destinations — write DataFrames to files, databases, and cloud storage.
+
+Provides a unified interface for exporting data to local files, remote databases,
+and cloud storage. Mirrors the connector module for symmetric source/destination
+handling.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+import polars as pl
+
+# =============================================================================
+# Public API
+# =============================================================================
+
+
+def export_to(
+    df: pl.DataFrame,
+    dest: str,
+    *,
+    format: str | None = None,
+    table: str | None = None,
+    mode: str = "replace",
+    name: str | None = None,
+) -> dict[str, Any]:
+    """Export a DataFrame to any supported destination.
+
+    Detects the destination type (file, cloud, database) and dispatches
+    to the appropriate exporter.
+
+    Args:
+        df: Polars DataFrame to export.
+        dest: Destination — file path, URL, or connection string.
+        format: Force a specific format (csv, parquet, json, etc.).
+        table: Table name for database destinations.
+        mode: Write mode for databases — 'replace', 'append', or 'fail'.
+        name: Optional name/label for the export.
+
+    Returns:
+        Metadata dict with keys like 'dest_type', 'dest', 'format', 'rows'.
+
+    Raises:
+        ValueError: If destination type can't be determined or format unsupported.
+        ConnectionError: If remote destination is unreachable.
+    """
+    dest_type = detect_dest_type(dest)
+
+    if dest_type == "file":
+        return _export_file(df, dest, format=format)
+    elif dest_type == "cloud":
+        return _export_cloud(df, dest, format=format)
+    elif dest_type == "database":
+        return _export_database(df, dest, table=table, mode=mode)
+    else:
+        raise ValueError(f"Cannot determine destination type for: {dest}")
+
+
+def detect_dest_type(dest: str) -> str:
+    """Detect the type of an export destination.
+
+    Args:
+        dest: Destination string to classify.
+
+    Returns:
+        One of: 'file', 'cloud', 'database'.
+    """
+    # Database connection strings
+    db_schemes = ("postgresql://", "postgres://", "mysql://", "sqlite://", "duckdb://")
+    if any(dest.startswith(s) for s in db_schemes):
+        return "database"
+
+    # Cloud storage
+    if dest.startswith(("s3://", "gs://", "az://", "abfs://")):
+        return "cloud"
+
+    # HTTP(S) — not typically an export destination, treat as error
+    if dest.startswith(("http://", "https://")):
+        raise ValueError(
+            "Cannot export to HTTP(S) URLs directly. "
+            "Use s3://, gs://, or a database connection string."
+        )
+
+    # Default: local file
+    return "file"
+
+
+# =============================================================================
+# Exporters
+# =============================================================================
+
+
+def _export_file(
+    df: pl.DataFrame, dest: str, *, format: str | None = None
+) -> dict[str, Any]:
+    """Export to a local file."""
+    path = Path(dest)
+
+    if format is None:
+        format = _detect_format(path)
+
+    # Ensure parent directory exists
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    _write_file(df, path, format)
+
+    return {
+        "dest_type": "file",
+        "dest": str(path.resolve()),
+        "format": format,
+        "rows": df.height,
+        "cols": df.width,
+    }
+
+
+def _export_cloud(
+    df: pl.DataFrame, dest: str, *, format: str | None = None
+) -> dict[str, Any]:
+    """Export to cloud storage (S3, GCS, Azure) via Polars native support."""
+    if format is None:
+        format = _format_from_path(dest) or "parquet"
+
+    if format == "csv":
+        df.write_csv(dest)
+    elif format == "parquet":
+        df.write_parquet(dest)
+    elif format in ("jsonl", "ndjson"):
+        df.write_ndjson(dest)
+    elif format == "ipc":
+        df.write_ipc(dest)
+    else:
+        raise ValueError(
+            f"Unsupported format for cloud export: '{format}'. "
+            "Supported: csv, parquet, ndjson, ipc."
+        )
+
+    return {
+        "dest_type": "cloud",
+        "dest": dest,
+        "format": format,
+        "rows": df.height,
+        "cols": df.width,
+    }
+
+
+def _export_database(
+    df: pl.DataFrame,
+    dest: str,
+    *,
+    table: str | None = None,
+    mode: str = "replace",
+) -> dict[str, Any]:
+    """Export to a database via DuckDB.
+
+    Supports: PostgreSQL, MySQL, SQLite, DuckDB files.
+    """
+    import duckdb
+
+    parsed = urlparse(dest)
+    scheme = parsed.scheme.lower()
+
+    if table is None:
+        table = "exported_data"
+
+    if mode not in ("replace", "append", "fail"):
+        raise ValueError(f"Invalid mode: '{mode}'. Use 'replace', 'append', or 'fail'.")
+
+    conn = duckdb.connect(":memory:")
+
+    # Register the DataFrame for DuckDB access
+    conn.register("export_df", df.to_arrow())
+
+    try:
+        if scheme in ("postgresql", "postgres"):
+            conn.execute("INSTALL postgres")
+            conn.execute("LOAD postgres")
+            db_url = dest.replace("postgresql://", "postgres://")
+            conn.execute(f"ATTACH '{db_url}' AS remote_db (TYPE postgres)")
+            _write_to_attached_db(conn, "remote_db", table, mode)
+
+        elif scheme == "mysql":
+            conn.execute("INSTALL mysql")
+            conn.execute("LOAD mysql")
+            conn.execute(f"ATTACH '{dest}' AS remote_db (TYPE mysql)")
+            _write_to_attached_db(conn, "remote_db", table, mode)
+
+        elif scheme == "sqlite":
+            db_path = parsed.path
+            if db_path.startswith("///"):
+                db_path = db_path[3:]
+            elif db_path.startswith("/"):
+                db_path = db_path[1:]
+            conn.execute("INSTALL sqlite")
+            conn.execute("LOAD sqlite")
+            conn.execute(f"ATTACH '{db_path}' AS remote_db (TYPE sqlite)")
+            _write_to_attached_db(conn, "remote_db", table, mode)
+
+        elif scheme == "duckdb":
+            db_path = parsed.path
+            if db_path.startswith("///"):
+                db_path = db_path[3:]
+            elif db_path.startswith("/"):
+                db_path = db_path[1:]
+            conn.execute(f"ATTACH '{db_path}' AS remote_db")
+            _write_to_attached_db(conn, "remote_db", table, mode)
+
+        else:
+            raise ValueError(f"Unsupported database scheme: '{scheme}'")
+
+    finally:
+        conn.close()
+
+    return {
+        "dest_type": "database",
+        "dest": _redact_credentials(dest),
+        "table": table,
+        "mode": mode,
+        "rows": df.height,
+        "cols": df.width,
+    }
+
+
+def _write_to_attached_db(conn, db_name: str, table: str, mode: str) -> None:
+    """Write export_df to a table in the attached database."""
+    qualified = f"{db_name}.{table}"
+
+    if mode == "replace":
+        conn.execute(f"DROP TABLE IF EXISTS {qualified}")
+        conn.execute(f"CREATE TABLE {qualified} AS SELECT * FROM export_df")
+    elif mode == "append":
+        # Create table if it doesn't exist, then insert
+        conn.execute(
+            f"CREATE TABLE IF NOT EXISTS {qualified} AS "
+            f"SELECT * FROM export_df WHERE 1=0"
+        )
+        conn.execute(f"INSERT INTO {qualified} SELECT * FROM export_df")
+    elif mode == "fail":
+        # This will fail if table already exists
+        conn.execute(f"CREATE TABLE {qualified} AS SELECT * FROM export_df")
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _write_file(df: pl.DataFrame, path: Path, format: str) -> None:
+    """Write a DataFrame to a file in the given format."""
+    writers = {
+        "csv": lambda d, p: d.write_csv(p),
+        "tsv": lambda d, p: d.write_csv(p, separator="\t"),
+        "parquet": lambda d, p: d.write_parquet(p),
+        "json": lambda d, p: d.write_json(p),
+        "jsonl": lambda d, p: d.write_ndjson(p),
+        "ndjson": lambda d, p: d.write_ndjson(p),
+        "ipc": lambda d, p: d.write_ipc(p),
+    }
+    writer = writers.get(format)
+    if writer is None:
+        raise ValueError(
+            f"Unsupported export format: '{format}'. "
+            f"Supported: {', '.join(writers.keys())}"
+        )
+    writer(df, path)
+
+
+def _detect_format(path: Path) -> str:
+    """Detect format from file extension."""
+    format_map = {
+        ".csv": "csv",
+        ".tsv": "tsv",
+        ".parquet": "parquet",
+        ".pq": "parquet",
+        ".json": "json",
+        ".jsonl": "jsonl",
+        ".ndjson": "ndjson",
+        ".ipc": "ipc",
+    }
+    fmt = format_map.get(path.suffix.lower())
+    if fmt is None:
+        raise ValueError(
+            f"Cannot detect export format from extension '{path.suffix}'. "
+            f"Supported: {', '.join(format_map.keys())}"
+        )
+    return fmt
+
+
+def _format_from_path(path: str) -> str | None:
+    """Extract format from a path string (best effort)."""
+    ext_map = {
+        ".csv": "csv",
+        ".tsv": "tsv",
+        ".parquet": "parquet",
+        ".pq": "parquet",
+        ".json": "json",
+        ".jsonl": "jsonl",
+        ".ndjson": "ndjson",
+        ".ipc": "ipc",
+    }
+    for ext, fmt in ext_map.items():
+        if path.endswith(ext):
+            return fmt
+    return None
+
+
+def _redact_credentials(url: str) -> str:
+    """Redact password from a connection string for safe logging."""
+    return re.sub(r"://([^:]+):([^@]+)@", r"://\1:***@", url)

--- a/sweet/core/workspace.py
+++ b/sweet/core/workspace.py
@@ -1525,35 +1525,44 @@ class Workspace:
     # Export
     # -------------------------------------------------------------------------
 
-    def export(self, dest: str | Path, *, format: str | None = None) -> "Workspace":
-        """Export the active sheet to a file.
+    def export(
+        self,
+        dest: str | Path,
+        *,
+        format: str | None = None,
+        table: str | None = None,
+        mode: str = "replace",
+    ) -> "Workspace":
+        """Export the active sheet to a file, database, or cloud storage.
 
         Args:
-            dest: Destination file path.
+            dest: Destination — file path, cloud URL (s3://, gs://), or
+                database connection string (postgresql://, sqlite://, etc.).
             format: File format. Auto-detected from extension if None.
+            table: Table name for database destinations.
+            mode: Write mode for databases — 'replace', 'append', or 'fail'.
 
         Returns:
             self (for method chaining).
 
         Raises:
-            ValueError: If no data to export or unsupported format.
+            ValueError: If no data to export or unsupported format/destination.
         """
+        from .exporters import export_to
+
         sheet = self._require_active_sheet()
 
         if sheet.df is None:
             raise ValueError("No data to export")
 
-        dest = Path(dest)
-
-        if format is None:
-            format = self._detect_format(dest)
-
-        sheet.save_to_file(dest, format)
+        meta = export_to(
+            sheet.df, str(dest), format=format, table=table, mode=mode
+        )
 
         self._record_operation(
             kind=OperationKind.EXPORT,
             sheet=sheet.name,
-            metadata={"dest": str(dest), "format": format},
+            metadata=meta,
         )
 
         return self

--- a/sweet/mcp.py
+++ b/sweet/mcp.py
@@ -201,21 +201,37 @@ async def list_tools() -> list[Tool]:
         ),
         Tool(
             name="sweet_export",
-            description="Export the active sheet to a file. Supports CSV, Parquet, and JSON.",
+            description=(
+                "Export the active sheet to a file, database, or cloud storage. "
+                "Supports local files (CSV, Parquet, JSON, TSV, NDJSON, IPC), "
+                "cloud (s3://, gs://, az://), and databases "
+                "(postgresql://, mysql://, sqlite://, duckdb://)."
+            ),
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "path": {
+                    "dest": {
                         "type": "string",
-                        "description": "Destination file path.",
+                        "description": (
+                            "Destination — file path, cloud URL (s3://...), "
+                            "or database connection string."
+                        ),
                     },
                     "format": {
                         "type": "string",
-                        "enum": ["csv", "parquet", "json"],
                         "description": "File format. Auto-detected from extension if omitted.",
                     },
+                    "table": {
+                        "type": "string",
+                        "description": "Table name (for database destinations).",
+                    },
+                    "mode": {
+                        "type": "string",
+                        "enum": ["replace", "append", "fail"],
+                        "description": "Write mode for databases. Default: 'replace'.",
+                    },
                 },
-                "required": ["path"],
+                "required": ["dest"],
             },
         ),
         Tool(
@@ -840,11 +856,17 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
             ]
 
         elif name == "sweet_export":
-            ws.export(arguments["path"], format=arguments.get("format"))
+            dest = arguments.get("dest") or arguments.get("path", "")
+            ws.export(
+                dest,
+                format=arguments.get("format"),
+                table=arguments.get("table"),
+                mode=arguments.get("mode", "replace"),
+            )
             return [
                 TextContent(
                     type="text",
-                    text=f"Exported to: {arguments['path']}",
+                    text=f"Exported {ws.shape[0]} rows × {ws.shape[1]} cols to: {dest}",
                 )
             ]
 

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -1,0 +1,281 @@
+"""Tests for sweet.core.exporters — export destinations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from sweet.core.exporters import (
+    _redact_credentials,
+    detect_dest_type,
+    export_to,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+SAMPLE_DF = pl.DataFrame({"name": ["Alice", "Bob", "Carol"], "age": [30, 25, 35]})
+
+
+# ---------------------------------------------------------------------------
+# detect_dest_type
+# ---------------------------------------------------------------------------
+
+
+class TestDetectDestType:
+    def test_local_file(self):
+        assert detect_dest_type("output.csv") == "file"
+        assert detect_dest_type("/tmp/data.parquet") == "file"
+        assert detect_dest_type("./results/out.json") == "file"
+
+    def test_cloud_storage(self):
+        assert detect_dest_type("s3://bucket/path/data.parquet") == "cloud"
+        assert detect_dest_type("gs://bucket/data.csv") == "cloud"
+        assert detect_dest_type("az://container/blob.parquet") == "cloud"
+        assert detect_dest_type("abfs://container/path.ipc") == "cloud"
+
+    def test_database(self):
+        assert detect_dest_type("postgresql://user:pass@host/db") == "database"
+        assert detect_dest_type("postgres://user:pass@host/db") == "database"
+        assert detect_dest_type("mysql://user:pass@host/db") == "database"
+        assert detect_dest_type("sqlite:///path/to/file.db") == "database"
+        assert detect_dest_type("duckdb:///path/to/file.duckdb") == "database"
+
+    def test_http_raises(self):
+        with pytest.raises(ValueError, match="Cannot export to HTTP"):
+            detect_dest_type("https://example.com/upload")
+
+
+# ---------------------------------------------------------------------------
+# export_to — local files
+# ---------------------------------------------------------------------------
+
+
+class TestExportFile:
+    def test_export_csv(self, tmp_path):
+        dest = str(tmp_path / "out.csv")
+        meta = export_to(SAMPLE_DF, dest)
+        assert meta["dest_type"] == "file"
+        assert meta["format"] == "csv"
+        assert meta["rows"] == 3
+
+        # Verify file was written
+        loaded = pl.read_csv(dest)
+        assert loaded.height == 3
+        assert list(loaded.columns) == ["name", "age"]
+
+    def test_export_parquet(self, tmp_path):
+        dest = str(tmp_path / "out.parquet")
+        meta = export_to(SAMPLE_DF, dest)
+        assert meta["format"] == "parquet"
+
+        loaded = pl.read_parquet(dest)
+        assert loaded.height == 3
+
+    def test_export_json(self, tmp_path):
+        dest = str(tmp_path / "out.json")
+        meta = export_to(SAMPLE_DF, dest)
+        assert meta["format"] == "json"
+
+        loaded = pl.read_json(dest)
+        assert loaded.height == 3
+
+    def test_export_ndjson(self, tmp_path):
+        dest = str(tmp_path / "out.ndjson")
+        meta = export_to(SAMPLE_DF, dest)
+        assert meta["format"] == "ndjson"
+
+        loaded = pl.read_ndjson(dest)
+        assert loaded.height == 3
+
+    def test_export_tsv(self, tmp_path):
+        dest = str(tmp_path / "out.tsv")
+        meta = export_to(SAMPLE_DF, dest)
+        assert meta["format"] == "tsv"
+
+        loaded = pl.read_csv(dest, separator="\t")
+        assert loaded.height == 3
+
+    def test_export_ipc(self, tmp_path):
+        dest = str(tmp_path / "out.ipc")
+        meta = export_to(SAMPLE_DF, dest)
+        assert meta["format"] == "ipc"
+
+        loaded = pl.read_ipc(dest)
+        assert loaded.height == 3
+
+    def test_forced_format(self, tmp_path):
+        dest = str(tmp_path / "output.dat")
+        meta = export_to(SAMPLE_DF, dest, format="csv")
+        assert meta["format"] == "csv"
+
+        loaded = pl.read_csv(dest)
+        assert loaded.height == 3
+
+    def test_creates_parent_dirs(self, tmp_path):
+        dest = str(tmp_path / "deep" / "nested" / "out.csv")
+        export_to(SAMPLE_DF, dest)
+        assert Path(dest).exists()
+
+    def test_unsupported_extension(self, tmp_path):
+        with pytest.raises(ValueError, match="Cannot detect export format"):
+            export_to(SAMPLE_DF, str(tmp_path / "out.xyz"))
+
+
+# ---------------------------------------------------------------------------
+# export_to — database (SQLite)
+# ---------------------------------------------------------------------------
+
+
+class TestExportDatabase:
+    def test_export_to_sqlite_replace(self, tmp_path):
+        import sqlite3
+
+        db_path = tmp_path / "test.db"
+        # Create the SQLite file
+        sqlite3.connect(str(db_path)).close()
+
+        meta = export_to(
+            SAMPLE_DF,
+            f"sqlite:///{db_path}",
+            table="people",
+        )
+        assert meta["dest_type"] == "database"
+        assert meta["table"] == "people"
+        assert meta["mode"] == "replace"
+        assert meta["rows"] == 3
+
+        # Verify data was written
+        conn = sqlite3.connect(str(db_path))
+        rows = conn.execute("SELECT COUNT(*) FROM people").fetchone()[0]
+        conn.close()
+        assert rows == 3
+
+    def test_export_to_sqlite_append(self, tmp_path):
+        import sqlite3
+
+        db_path = tmp_path / "test.db"
+        sqlite3.connect(str(db_path)).close()
+
+        # First write
+        export_to(SAMPLE_DF, f"sqlite:///{db_path}", table="items")
+        # Append
+        export_to(SAMPLE_DF, f"sqlite:///{db_path}", table="items", mode="append")
+
+        conn = sqlite3.connect(str(db_path))
+        rows = conn.execute("SELECT COUNT(*) FROM items").fetchone()[0]
+        conn.close()
+        assert rows == 6
+
+    def test_export_to_sqlite_fail_mode(self, tmp_path):
+        import sqlite3
+
+        db_path = tmp_path / "test.db"
+        sqlite3.connect(str(db_path)).close()
+
+        # First write succeeds
+        export_to(SAMPLE_DF, f"sqlite:///{db_path}", table="unique_table", mode="fail")
+
+        # Second write should fail
+        with pytest.raises(Exception):
+            export_to(SAMPLE_DF, f"sqlite:///{db_path}", table="unique_table", mode="fail")
+
+    def test_default_table_name(self, tmp_path):
+        import sqlite3
+
+        db_path = tmp_path / "test.db"
+        sqlite3.connect(str(db_path)).close()
+
+        meta = export_to(SAMPLE_DF, f"sqlite:///{db_path}")
+        assert meta["table"] == "exported_data"
+
+    def test_invalid_mode(self, tmp_path):
+        with pytest.raises(ValueError, match="Invalid mode"):
+            export_to(SAMPLE_DF, "sqlite:///test.db", mode="bad")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class TestRedactCredentials:
+    def test_redacts_password(self):
+        url = "postgresql://user:secret@host:5432/db"
+        assert _redact_credentials(url) == "postgresql://user:***@host:5432/db"
+
+    def test_no_credentials(self):
+        url = "sqlite:///path/to/file.db"
+        assert _redact_credentials(url) == url
+
+
+# ---------------------------------------------------------------------------
+# Integration: Workspace.export()
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceExportIntegration:
+    def test_export_to_parquet(self, tmp_path):
+        from sweet.core.workspace import Workspace
+
+        csv_file = tmp_path / "input.csv"
+        SAMPLE_DF.write_csv(csv_file)
+
+        ws = Workspace()
+        ws.load(str(csv_file))
+
+        dest = str(tmp_path / "out.parquet")
+        ws.export(dest)
+        assert Path(dest).exists()
+        assert pl.read_parquet(dest).height == 3
+
+    def test_export_to_ndjson(self, tmp_path):
+        from sweet.core.workspace import Workspace
+
+        csv_file = tmp_path / "input.csv"
+        SAMPLE_DF.write_csv(csv_file)
+
+        ws = Workspace()
+        ws.load(str(csv_file))
+
+        dest = str(tmp_path / "out.ndjson")
+        ws.export(dest)
+        assert Path(dest).exists()
+        assert pl.read_ndjson(dest).height == 3
+
+    def test_export_to_sqlite(self, tmp_path):
+        import sqlite3
+
+        from sweet.core.workspace import Workspace
+
+        csv_file = tmp_path / "input.csv"
+        SAMPLE_DF.write_csv(csv_file)
+        db_path = tmp_path / "out.db"
+        sqlite3.connect(str(db_path)).close()
+
+        ws = Workspace()
+        ws.load(str(csv_file))
+        ws.export(f"sqlite:///{db_path}", table="exported")
+
+        conn = sqlite3.connect(str(db_path))
+        rows = conn.execute("SELECT COUNT(*) FROM exported").fetchone()[0]
+        conn.close()
+        assert rows == 3
+
+    def test_export_multiple_formats(self, tmp_path):
+        from sweet.core.workspace import Workspace
+
+        csv_file = tmp_path / "input.csv"
+        SAMPLE_DF.write_csv(csv_file)
+
+        ws = Workspace()
+        ws.load(str(csv_file))
+
+        for ext in ("csv", "parquet", "json", "ndjson", "tsv", "ipc"):
+            dest = str(tmp_path / f"out.{ext}")
+            ws.export(dest)
+            assert Path(dest).exists(), f"Failed for format: {ext}"


### PR DESCRIPTION
This PR adds a unified export system to the project, enabling data to be exported from the workspace to local files, cloud storage (such as S3 or GCS), and databases (such as PostgreSQL, MySQL, SQLite, DuckDB). It introduces a new `export` CLI command, a core `exporters` module, and expands the `Workspace.export()` method and tool interface to support these destinations and formats.