### PR TITLE
Phase 5.3

### DIFF
--- a/sweet/cli.py
+++ b/sweet/cli.py
@@ -1268,5 +1268,67 @@ def _load_file_as_df(path: str):
         raise click.BadParameter(f"Unsupported file format: {suffix}")
 
 
+# =============================================================================
+# Bundle commands (shareable workspaces)
+# =============================================================================
+
+
+@main.command()
+@click.argument("file", type=click.Path(exists=True))
+@click.argument("output", type=click.Path())
+@click.option("--description", "-d", default="", help="Description for the bundle")
+@click.option("--no-journal", is_flag=True, help="Exclude operation history")
+def share(file: str, output: str, description: str, no_journal: bool):
+    """Save a dataset as a shareable .sweet bundle.
+
+    Example:
+        sweet share sales.csv sales-analysis
+        sweet share data.csv my-bundle -d "Cleaned Q4 data"
+    """
+    from .core.workspace import Workspace
+
+    ws = Workspace()
+    ws.load(file)
+    result = ws.save(output, description=description, include_journal=not no_journal)
+    size_kb = result.stat().st_size / 1024
+    click.echo(f"\n  ✓ Bundle saved: {result} ({size_kb:.1f} KB)")
+    click.echo(f"    Sheets: {len(ws.sheet_names)} | Description: {description or '(none)'}")
+    click.echo()
+
+
+@main.command(name="open")
+@click.argument("bundle", type=click.Path(exists=True))
+@click.option("--info", "info_only", is_flag=True, help="Just show bundle info, don't open TUI")
+def open_bundle(bundle: str, info_only: bool):
+    """Open a .sweet bundle (inspect or launch TUI).
+
+    Example:
+        sweet open analysis.sweet --info
+        sweet open analysis.sweet
+    """
+    if info_only:
+        from .core.workspace import Workspace
+
+        info = Workspace.inspect_bundle(bundle)
+        manifest = info["manifest"]
+        click.echo(f"\n  Bundle: {bundle}")
+        click.echo(f"  Created: {manifest['created_at'][:19]}")
+        click.echo(f"  Description: {manifest.get('description') or '(none)'}")
+        click.echo(f"  File size: {info['file_size'] / 1024:.1f} KB")
+        click.echo(f"\n  Sheets ({len(manifest['sheets'])}):")
+        for s in manifest["sheets"]:
+            shape = f"{s['shape'][0]}×{s['shape'][1]}"
+            click.echo(f"    • {s['name']} ({shape}, {s['n_transforms']} transforms)")
+        click.echo()
+    else:
+        from .core.workspace import Workspace
+
+        ws = Workspace.open(bundle)
+        click.echo(f"  ✓ Restored workspace from {bundle}")
+        click.echo(f"    Sheets: {', '.join(ws.sheet_names)}")
+        click.echo(f"    Active: {ws.current_sheet_name}")
+        click.echo()
+
+
 if __name__ == "__main__":
     main()

--- a/sweet/core/bundle.py
+++ b/sweet/core/bundle.py
@@ -1,0 +1,218 @@
+"""Shareable workspace bundles — save/restore full workspace state as .sweet files.
+
+A .sweet bundle is a ZIP archive containing:
+- manifest.json  — metadata, sheet list, schema, creation info
+- data/<name>.parquet  — Parquet-serialized data for each sheet
+- transforms.json  — transform history per sheet (reproducible steps)
+- journal.json  — operation journal (without DataFrame snapshots)
+"""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from datetime import datetime, timezone
+from io import BytesIO
+from pathlib import Path
+from typing import Any
+
+import polars as pl
+
+BUNDLE_VERSION = 1
+BUNDLE_EXTENSION = ".sweet"
+
+
+def save_bundle(
+    workspace: Any,
+    path: str | Path,
+    *,
+    description: str = "",
+    include_journal: bool = True,
+) -> Path:
+    """Save a workspace as a .sweet bundle file.
+
+    Args:
+        workspace: The Workspace instance to serialize.
+        path: Output file path. Extension .sweet is added if missing.
+        description: Optional description for the bundle.
+        include_journal: Whether to include operation history.
+
+    Returns:
+        Path to the created bundle file.
+
+    Raises:
+        ValueError: If the workspace has no sheets or no data.
+    """
+    path = Path(path)
+    if path.suffix != BUNDLE_EXTENSION:
+        path = path.with_suffix(BUNDLE_EXTENSION)
+
+    if not workspace.sheet_names:
+        raise ValueError("Cannot save an empty workspace — no sheets loaded.")
+
+    # Build manifest
+    sheets_meta: list[dict[str, Any]] = []
+    for name in workspace.sheet_names:
+        sheet = workspace._workbook.sheets[name]
+        if sheet.df is None:
+            continue
+        sheets_meta.append(
+            {
+                "name": name,
+                "shape": list(sheet.df.shape),
+                "schema": {col: str(dtype) for col, dtype in sheet.df.schema.items()},
+                "n_transforms": len(sheet.transform_steps),
+            }
+        )
+
+    if not sheets_meta:
+        raise ValueError("No sheets with data to save.")
+
+    manifest = {
+        "bundle_version": BUNDLE_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "description": description,
+        "current_sheet": workspace.current_sheet_name,
+        "source_file": getattr(workspace, "_source_file", None),
+        "sheets": sheets_meta,
+    }
+
+    # Build transforms
+    transforms: dict[str, list[dict[str, Any]]] = {}
+    for name in workspace.sheet_names:
+        sheet = workspace._workbook.sheets[name]
+        steps = []
+        for step in sheet.transform_steps:
+            steps.append(
+                {
+                    "expr": step.expr,
+                    "input_hash": step.input_hash,
+                    "output_schema": step.output_schema,
+                    "metadata": step.metadata,
+                }
+            )
+        transforms[name] = steps
+
+    # Build journal (without snapshots)
+    journal_data: list[dict[str, Any]] = []
+    if include_journal:
+        for op in workspace.history():
+            journal_data.append(
+                {
+                    "id": op.id,
+                    "timestamp": op.timestamp.isoformat(),
+                    "kind": op.kind.value,
+                    "sheet": op.sheet,
+                    "expr": op.expr,
+                    "metadata": op.metadata,
+                    "input_hash": op.input_hash,
+                    "output_hash": op.output_hash,
+                }
+            )
+
+    # Write ZIP
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("manifest.json", json.dumps(manifest, indent=2))
+        zf.writestr("transforms.json", json.dumps(transforms, indent=2))
+        zf.writestr("journal.json", json.dumps(journal_data, indent=2))
+
+        for name in workspace.sheet_names:
+            sheet = workspace._workbook.sheets[name]
+            if sheet.df is not None:
+                buf = BytesIO()
+                sheet.df.write_parquet(buf)
+                zf.writestr(f"data/{name}.parquet", buf.getvalue())
+
+    return path
+
+
+def load_bundle(path: str | Path) -> dict[str, Any]:
+    """Load a .sweet bundle and return its contents.
+
+    Returns a dict that can be used to restore a Workspace:
+    - "manifest": bundle metadata
+    - "sheets": dict of {name: pl.DataFrame}
+    - "transforms": dict of {name: list of transform step dicts}
+    - "journal": list of operation dicts
+
+    Args:
+        path: Path to the .sweet bundle file.
+
+    Returns:
+        Dict with manifest, sheets, transforms, and journal.
+
+    Raises:
+        ValueError: If the file is not a valid .sweet bundle.
+        FileNotFoundError: If the file doesn't exist.
+    """
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"Bundle not found: {path}")
+
+    try:
+        with zipfile.ZipFile(path, "r") as zf:
+            # Read manifest
+            manifest = json.loads(zf.read("manifest.json"))
+
+            # Read transforms
+            transforms = json.loads(zf.read("transforms.json"))
+
+            # Read journal
+            journal: list[dict[str, Any]] = []
+            if "journal.json" in zf.namelist():
+                journal = json.loads(zf.read("journal.json"))
+
+            # Read data files
+            sheets: dict[str, pl.DataFrame] = {}
+            for entry in zf.namelist():
+                if entry.startswith("data/") and entry.endswith(".parquet"):
+                    sheet_name = entry.removeprefix("data/").removesuffix(".parquet")
+                    buf = BytesIO(zf.read(entry))
+                    sheets[sheet_name] = pl.read_parquet(buf)
+
+    except (zipfile.BadZipFile, KeyError) as e:
+        raise ValueError(f"Invalid .sweet bundle: {e}") from e
+
+    return {
+        "manifest": manifest,
+        "sheets": sheets,
+        "transforms": transforms,
+        "journal": journal,
+    }
+
+
+def inspect_bundle(path: str | Path) -> dict[str, Any]:
+    """Inspect a .sweet bundle without fully loading data.
+
+    Returns metadata about the bundle without reading Parquet data.
+
+    Args:
+        path: Path to the .sweet bundle file.
+
+    Returns:
+        Dict with manifest info, file size, and sheet summaries.
+    """
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"Bundle not found: {path}")
+
+    try:
+        with zipfile.ZipFile(path, "r") as zf:
+            manifest = json.loads(zf.read("manifest.json"))
+
+            # Calculate data sizes
+            data_sizes: dict[str, int] = {}
+            for entry in zf.namelist():
+                if entry.startswith("data/") and entry.endswith(".parquet"):
+                    sheet_name = entry.removeprefix("data/").removesuffix(".parquet")
+                    info = zf.getinfo(entry)
+                    data_sizes[sheet_name] = info.file_size
+
+    except (zipfile.BadZipFile, KeyError) as e:
+        raise ValueError(f"Invalid .sweet bundle: {e}") from e
+
+    return {
+        "manifest": manifest,
+        "file_size": path.stat().st_size,
+        "data_sizes": data_sizes,
+    }

--- a/sweet/core/workspace.py
+++ b/sweet/core/workspace.py
@@ -1233,6 +1233,101 @@ class Workspace:
         return store.forget(kind=kind, trigger=trigger)
 
     # -------------------------------------------------------------------------
+    # Bundle (Shareable Workspaces)
+    # -------------------------------------------------------------------------
+
+    def save(
+        self,
+        path: str | Path,
+        *,
+        description: str = "",
+        include_journal: bool = True,
+    ) -> Path:
+        """Save the workspace as a .sweet bundle file.
+
+        Creates a portable archive containing all sheets, transforms,
+        and operation history that can be shared and restored.
+
+        Args:
+            path: Output file path (.sweet extension added if missing).
+            description: Optional description for the bundle.
+            include_journal: Whether to include operation history.
+
+        Returns:
+            Path to the created bundle file.
+
+        Raises:
+            ValueError: If no sheets or no data loaded.
+        """
+        from .bundle import save_bundle
+
+        return save_bundle(
+            self, path, description=description, include_journal=include_journal
+        )
+
+    @classmethod
+    def open(cls, path: str | Path) -> "Workspace":
+        """Restore a workspace from a .sweet bundle file.
+
+        Args:
+            path: Path to the .sweet bundle file.
+
+        Returns:
+            A new Workspace instance with restored state.
+
+        Raises:
+            ValueError: If the file is not a valid bundle.
+            FileNotFoundError: If the file doesn't exist.
+        """
+        from .bundle import load_bundle
+        from .transforms import TransformStep
+
+        bundle = load_bundle(path)
+        ws = cls()
+
+        # Restore sheets
+        for name, df in bundle["sheets"].items():
+            ws.load_df(df, name=name)
+
+            # Restore transform steps
+            if name in bundle["transforms"]:
+                sheet = ws._workbook.sheets[name]
+                for step_data in bundle["transforms"][name]:
+                    step = TransformStep(
+                        expr=step_data["expr"],
+                        input_hash=step_data["input_hash"],
+                        output_schema=step_data["output_schema"],
+                        metadata=step_data.get("metadata"),
+                    )
+                    sheet.transform_steps.append(step)
+
+        # Restore current sheet
+        current = bundle["manifest"].get("current_sheet")
+        if current and current in ws.sheet_names:
+            ws._workbook.set_current_sheet(current)
+
+        # Restore source file reference
+        source = bundle["manifest"].get("source_file")
+        if source:
+            ws._source_file = source
+
+        return ws
+
+    @staticmethod
+    def inspect_bundle(path: str | Path) -> dict[str, Any]:
+        """Inspect a .sweet bundle without fully loading it.
+
+        Args:
+            path: Path to the .sweet bundle file.
+
+        Returns:
+            Dict with manifest, file size, and data sizes per sheet.
+        """
+        from .bundle import inspect_bundle
+
+        return inspect_bundle(path)
+
+    # -------------------------------------------------------------------------
     # Correlation Analysis
     # -------------------------------------------------------------------------
 

--- a/sweet/mcp.py
+++ b/sweet/mcp.py
@@ -921,6 +921,58 @@ async def list_tools() -> list[Tool]:
                 },
             },
         ),
+        Tool(
+            name="sweet_save_bundle",
+            description=(
+                "Save the workspace as a shareable .sweet bundle file containing "
+                "all sheets, transforms, and history."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Output file path (.sweet extension added if missing).",
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Description for the bundle.",
+                    },
+                },
+                "required": ["path"],
+            },
+        ),
+        Tool(
+            name="sweet_open_bundle",
+            description=(
+                "Restore a workspace from a .sweet bundle file. "
+                "Replaces the current workspace state."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Path to the .sweet bundle file.",
+                    },
+                },
+                "required": ["path"],
+            },
+        ),
+        Tool(
+            name="sweet_inspect_bundle",
+            description="Inspect a .sweet bundle file without loading it. Shows metadata and sheet info.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Path to the .sweet bundle file.",
+                    },
+                },
+                "required": ["path"],
+            },
+        ),
     ]
 
 
@@ -1551,6 +1603,34 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
             key_columns = arguments.get("key_columns")
             result = ws.diff(target, key_columns=key_columns)
             return [TextContent(type="text", text=json.dumps(result, default=str))]
+
+        elif name == "sweet_save_bundle":
+            result_path = ws.save(
+                arguments["path"],
+                description=arguments.get("description", ""),
+            )
+            return [TextContent(type="text", text=f"Bundle saved: {result_path}")]
+
+        elif name == "sweet_open_bundle":
+            global _workspace
+            from .core.workspace import Workspace as WS
+
+            _workspace = WS.open(arguments["path"])
+            info = _workspace.inspect()
+            return [
+                TextContent(
+                    type="text",
+                    text=f"Restored workspace from bundle. "
+                    f"Sheets: {', '.join(_workspace.sheet_names)}. "
+                    f"Active: {info['name']} ({info['shape'][0]}×{info['shape'][1]})",
+                )
+            ]
+
+        elif name == "sweet_inspect_bundle":
+            from .core.workspace import Workspace as WS
+
+            info = WS.inspect_bundle(arguments["path"])
+            return [TextContent(type="text", text=json.dumps(info, default=str))]
 
         else:
             return [TextContent(type="text", text=f"Unknown tool: {name}")]

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -1,0 +1,279 @@
+"""Tests for sweet.core.bundle — Shareable workspace bundles."""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from sweet.core.bundle import (
+    BUNDLE_EXTENSION,
+    BUNDLE_VERSION,
+    inspect_bundle,
+    load_bundle,
+    save_bundle,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+SAMPLE_DF = pl.DataFrame(
+    {
+        "id": [1, 2, 3],
+        "name": ["Alice", "Bob", "Carol"],
+        "score": [95.5, 87.3, 76.0],
+    }
+)
+
+SECOND_DF = pl.DataFrame(
+    {
+        "product": ["Widget", "Gadget"],
+        "price": [9.99, 19.99],
+    }
+)
+
+
+@pytest.fixture
+def workspace():
+    from sweet.core.workspace import Workspace
+
+    ws = Workspace()
+    ws.load_df(SAMPLE_DF, name="data")
+    return ws
+
+
+@pytest.fixture
+def workspace_with_transforms():
+    from sweet.core.workspace import Workspace
+
+    ws = Workspace()
+    ws.load_df(SAMPLE_DF, name="data")
+    ws.transform("df.filter(pl.col('score') > 80)", description="filter high scores")
+    return ws
+
+
+@pytest.fixture
+def multi_sheet_workspace():
+    from sweet.core.workspace import Workspace
+
+    ws = Workspace()
+    ws.load_df(SAMPLE_DF, name="people")
+    ws.load_df(SECOND_DF, name="products")
+    ws.switch("people")
+    return ws
+
+
+# ---------------------------------------------------------------------------
+# save_bundle
+# ---------------------------------------------------------------------------
+
+
+class TestSaveBundle:
+    def test_creates_file(self, workspace, tmp_path):
+        out = save_bundle(workspace, tmp_path / "test")
+        assert out.exists()
+        assert out.suffix == BUNDLE_EXTENSION
+
+    def test_adds_extension(self, workspace, tmp_path):
+        out = save_bundle(workspace, tmp_path / "test")
+        assert out.name == "test.sweet"
+
+    def test_keeps_extension(self, workspace, tmp_path):
+        out = save_bundle(workspace, tmp_path / "test.sweet")
+        assert out.name == "test.sweet"
+
+    def test_is_valid_zip(self, workspace, tmp_path):
+        out = save_bundle(workspace, tmp_path / "test")
+        assert zipfile.is_zipfile(out)
+
+    def test_contains_manifest(self, workspace, tmp_path):
+        out = save_bundle(workspace, tmp_path / "test")
+        with zipfile.ZipFile(out, "r") as zf:
+            manifest = json.loads(zf.read("manifest.json"))
+            assert manifest["bundle_version"] == BUNDLE_VERSION
+            assert len(manifest["sheets"]) == 1
+            assert manifest["sheets"][0]["name"] == "data"
+
+    def test_contains_data(self, workspace, tmp_path):
+        out = save_bundle(workspace, tmp_path / "test")
+        with zipfile.ZipFile(out, "r") as zf:
+            assert "data/data.parquet" in zf.namelist()
+
+    def test_contains_transforms(self, workspace_with_transforms, tmp_path):
+        out = save_bundle(workspace_with_transforms, tmp_path / "test")
+        with zipfile.ZipFile(out, "r") as zf:
+            transforms = json.loads(zf.read("transforms.json"))
+            assert "data" in transforms
+            assert len(transforms["data"]) > 0
+
+    def test_contains_journal(self, workspace_with_transforms, tmp_path):
+        out = save_bundle(workspace_with_transforms, tmp_path / "test")
+        with zipfile.ZipFile(out, "r") as zf:
+            journal = json.loads(zf.read("journal.json"))
+            assert len(journal) > 0
+
+    def test_no_journal_option(self, workspace_with_transforms, tmp_path):
+        out = save_bundle(workspace_with_transforms, tmp_path / "test", include_journal=False)
+        with zipfile.ZipFile(out, "r") as zf:
+            journal = json.loads(zf.read("journal.json"))
+            assert len(journal) == 0
+
+    def test_description(self, workspace, tmp_path):
+        out = save_bundle(workspace, tmp_path / "test", description="My analysis")
+        with zipfile.ZipFile(out, "r") as zf:
+            manifest = json.loads(zf.read("manifest.json"))
+            assert manifest["description"] == "My analysis"
+
+    def test_multi_sheet(self, multi_sheet_workspace, tmp_path):
+        out = save_bundle(multi_sheet_workspace, tmp_path / "test")
+        with zipfile.ZipFile(out, "r") as zf:
+            manifest = json.loads(zf.read("manifest.json"))
+            assert len(manifest["sheets"]) == 2
+            names = {s["name"] for s in manifest["sheets"]}
+            assert names == {"people", "products"}
+
+    def test_empty_workspace_raises(self, tmp_path):
+        from sweet.core.workspace import Workspace
+
+        ws = Workspace()
+        with pytest.raises(ValueError, match="no sheets"):
+            save_bundle(ws, tmp_path / "test")
+
+
+# ---------------------------------------------------------------------------
+# load_bundle
+# ---------------------------------------------------------------------------
+
+
+class TestLoadBundle:
+    def test_roundtrip(self, workspace, tmp_path):
+        out = save_bundle(workspace, tmp_path / "test")
+        bundle = load_bundle(out)
+        assert "data" in bundle["sheets"]
+        assert bundle["sheets"]["data"].equals(SAMPLE_DF)
+
+    def test_roundtrip_with_transforms(self, workspace_with_transforms, tmp_path):
+        out = save_bundle(workspace_with_transforms, tmp_path / "test")
+        bundle = load_bundle(out)
+        assert len(bundle["transforms"]["data"]) > 0
+
+    def test_roundtrip_multi_sheet(self, multi_sheet_workspace, tmp_path):
+        out = save_bundle(multi_sheet_workspace, tmp_path / "test")
+        bundle = load_bundle(out)
+        assert len(bundle["sheets"]) == 2
+        assert "people" in bundle["sheets"]
+        assert "products" in bundle["sheets"]
+
+    def test_manifest_preserved(self, workspace, tmp_path):
+        out = save_bundle(workspace, tmp_path / "test", description="Test bundle")
+        bundle = load_bundle(out)
+        assert bundle["manifest"]["description"] == "Test bundle"
+
+    def test_file_not_found(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            load_bundle(tmp_path / "nonexistent.sweet")
+
+    def test_invalid_zip(self, tmp_path):
+        bad_file = tmp_path / "bad.sweet"
+        bad_file.write_text("not a zip file")
+        with pytest.raises(ValueError, match="Invalid"):
+            load_bundle(bad_file)
+
+    def test_journal_preserved(self, workspace_with_transforms, tmp_path):
+        out = save_bundle(workspace_with_transforms, tmp_path / "test")
+        bundle = load_bundle(out)
+        assert len(bundle["journal"]) > 0
+        assert "kind" in bundle["journal"][0]
+
+
+# ---------------------------------------------------------------------------
+# inspect_bundle
+# ---------------------------------------------------------------------------
+
+
+class TestInspectBundle:
+    def test_inspect_metadata(self, workspace, tmp_path):
+        out = save_bundle(workspace, tmp_path / "test", description="Inspectable")
+        info = inspect_bundle(out)
+        assert info["manifest"]["description"] == "Inspectable"
+        assert info["file_size"] > 0
+
+    def test_inspect_data_sizes(self, workspace, tmp_path):
+        out = save_bundle(workspace, tmp_path / "test")
+        info = inspect_bundle(out)
+        assert "data" in info["data_sizes"]
+        assert info["data_sizes"]["data"] > 0
+
+    def test_inspect_not_found(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            inspect_bundle(tmp_path / "missing.sweet")
+
+
+# ---------------------------------------------------------------------------
+# Workspace integration
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceBundle:
+    def test_workspace_save(self, workspace, tmp_path):
+        result = workspace.save(tmp_path / "ws-bundle")
+        assert result.exists()
+        assert result.suffix == ".sweet"
+
+    def test_workspace_open(self, workspace, tmp_path):
+        from sweet.core.workspace import Workspace
+
+        workspace.save(tmp_path / "ws-bundle")
+        restored = Workspace.open(tmp_path / "ws-bundle.sweet")
+        assert restored.sheet_names == workspace.sheet_names
+        assert restored.current_sheet_name == workspace.current_sheet_name
+        assert restored.df.equals(workspace.df)
+
+    def test_workspace_open_with_transforms(self, workspace_with_transforms, tmp_path):
+        from sweet.core.workspace import Workspace
+
+        workspace_with_transforms.save(tmp_path / "ws-bundle")
+        restored = Workspace.open(tmp_path / "ws-bundle.sweet")
+        # Transform steps should be restored
+        sheet = restored._workbook.sheets["data"]
+        assert len(sheet.transform_steps) > 0
+
+    def test_workspace_open_multi_sheet(self, multi_sheet_workspace, tmp_path):
+        from sweet.core.workspace import Workspace
+
+        multi_sheet_workspace.save(tmp_path / "ws-bundle")
+        restored = Workspace.open(tmp_path / "ws-bundle.sweet")
+        assert set(restored.sheet_names) == {"people", "products"}
+        assert restored.current_sheet_name == "people"
+
+    def test_workspace_inspect_bundle(self, workspace, tmp_path):
+        from sweet.core.workspace import Workspace
+
+        workspace.save(tmp_path / "info-bundle")
+        info = Workspace.inspect_bundle(tmp_path / "info-bundle.sweet")
+        assert info["manifest"]["bundle_version"] == BUNDLE_VERSION
+        assert info["file_size"] > 0
+
+    def test_roundtrip_data_integrity(self, tmp_path):
+        """Verify data survives save → open cycle exactly."""
+        from sweet.core.workspace import Workspace
+
+        original = Workspace()
+        df = pl.DataFrame(
+            {
+                "int_col": [1, 2, None],
+                "float_col": [1.5, None, 3.5],
+                "str_col": ["hello", "world", None],
+                "bool_col": [True, False, True],
+            }
+        )
+        original.load_df(df, name="mixed_types")
+        original.save(tmp_path / "integrity")
+
+        restored = Workspace.open(tmp_path / "integrity.sweet")
+        assert restored.df.equals(df)


### PR DESCRIPTION
This PR introduces a new feature for creating, sharing, and restoring portable workspace bundles in the `.sweet` format. These bundles encapsulate all sheets, transforms, and operation history, making it easy to save and share complete workspace states. The changes include new CLI commands, core serialization logic, and integration with the MCP tool system.