### PR TITLE
feat: HTTP REST API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ requires-python = ">=3.10"
 
 [project.optional-dependencies]
 mcp = ["mcp>=1.0.0"]
+http = ["starlette>=0.27.0", "uvicorn>=0.23.0"]
 
 [dependency-groups]
 dev = [

--- a/sweet/cli.py
+++ b/sweet/cli.py
@@ -831,12 +831,16 @@ def run(file: str, steps: tuple[str, ...], fmt: str, no_validate: bool, no_rollb
 @click.option(
     "--mcp", "protocol", flag_value="mcp", default=True, help="Use MCP protocol (default)"
 )
-@click.option("--port", type=int, default=None, help="Port for HTTP mode (not yet implemented)")
-def serve(protocol: str, port: int | None):
-    """Start Sweet as an MCP tool server for AI agents.
+@click.option("--http", "protocol", flag_value="http", help="Use HTTP REST API")
+@click.option("--port", type=int, default=8421, help="Port for HTTP mode (default: 8421)")
+@click.option("--host", type=str, default="127.0.0.1", help="Host to bind (default: 127.0.0.1)")
+def serve(protocol: str, port: int, host: str):
+    """Start Sweet as a server for AI agents or HTTP clients.
 
     Example:
         sweet serve --mcp
+        sweet serve --http
+        sweet serve --http --port 9000 --host 0.0.0.0
     """
     import asyncio
 
@@ -846,8 +850,10 @@ def serve(protocol: str, port: int | None):
         click.echo("Starting Sweet MCP server (stdio)...", err=True)
         asyncio.run(run_mcp_server())
     else:
-        click.echo("HTTP mode not yet implemented.", err=True)
-        raise SystemExit(1)
+        from .http_api import run_http_server
+
+        click.echo(f"Starting Sweet HTTP API on {host}:{port}...", err=True)
+        run_http_server(host=host, port=port)
 
 
 # =============================================================================

--- a/sweet/http_api.py
+++ b/sweet/http_api.py
@@ -1,0 +1,491 @@
+"""HTTP REST API for Sweet — exposes the Workspace engine over HTTP.
+
+Provides the same operations as the MCP server but via standard REST endpoints,
+enabling non-MCP clients (web UIs, curl, webhooks, other languages) to drive Sweet.
+
+Usage:
+    sweet serve --http --port 8421
+"""
+
+from __future__ import annotations
+
+import json
+
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.middleware.cors import CORSMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+from .core.workspace import Workspace
+
+# ---------------------------------------------------------------------------
+# Workspace singleton
+# ---------------------------------------------------------------------------
+
+_workspace: Workspace | None = None
+
+
+def _get_workspace() -> Workspace:
+    global _workspace
+    if _workspace is None:
+        _workspace = Workspace()
+    return _workspace
+
+
+def reset_workspace() -> None:
+    """Reset the workspace (for testing)."""
+    global _workspace
+    _workspace = None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _error(message: str, status: int = 400) -> JSONResponse:
+    return JSONResponse({"error": message}, status_code=status)
+
+
+async def _get_body(request: Request) -> dict:
+    """Parse JSON body, returning empty dict if no body."""
+    body = await request.body()
+    if not body:
+        return {}
+    return json.loads(body)
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+async def health(request: Request) -> JSONResponse:
+    """Health check."""
+    ws = _get_workspace()
+    return JSONResponse({
+        "status": "ok",
+        "active_sheet": ws._workbook.current_sheet_name,
+        "sheets": ws.sheet_names,
+    })
+
+
+async def load(request: Request) -> JSONResponse:
+    """Load a file into the workspace.
+
+    Body: {"path": "file.csv", "name": "optional_sheet_name"}
+    """
+    ws = _get_workspace()
+    data = await _get_body(request)
+
+    path = data.get("path")
+    if not path:
+        return _error("'path' is required")
+
+    try:
+        ws.load(path, name=data.get("name"))
+        info = ws.inspect()
+        return JSONResponse({
+            "loaded": path,
+            "shape": info["shape"],
+            "columns": list(info["schema"].keys()),
+        })
+    except Exception as e:
+        return _error(f"{type(e).__name__}: {e}")
+
+
+async def inspect(request: Request) -> JSONResponse:
+    """Inspect the active sheet — schema, shape, sample rows."""
+    ws = _get_workspace()
+    try:
+        info = ws.inspect()
+        return JSONResponse(info)
+    except Exception as e:
+        return _error(f"{type(e).__name__}: {e}")
+
+
+async def transform(request: Request) -> JSONResponse:
+    """Apply a Polars expression.
+
+    Body: {"expr": "df.filter(pl.col('x') > 5)"}
+    """
+    ws = _get_workspace()
+    data = await _get_body(request)
+
+    expr = data.get("expr")
+    if not expr:
+        return _error("'expr' is required")
+
+    try:
+        ws.transform(expr)
+        info = ws.inspect()
+        return JSONResponse({"transformed": True, "shape": info["shape"]})
+    except Exception as e:
+        return _error(f"{type(e).__name__}: {e}")
+
+
+async def query(request: Request) -> JSONResponse:
+    """Run SQL via DuckDB.
+
+    Body: {"sql": "SELECT * FROM active LIMIT 10"}
+    """
+    ws = _get_workspace()
+    data = await _get_body(request)
+
+    sql = data.get("sql")
+    if not sql:
+        return _error("'sql' is required")
+
+    try:
+        ws.query(sql)
+        info = ws.inspect()
+        return JSONResponse({"queried": True, "shape": info["shape"]})
+    except Exception as e:
+        return _error(f"{type(e).__name__}: {e}")
+
+
+async def filter_rows(request: Request) -> JSONResponse:
+    """Filter rows by condition.
+
+    Body: {"condition": "pl.col('age') > 30"}
+    """
+    ws = _get_workspace()
+    data = await _get_body(request)
+
+    condition = data.get("condition")
+    if not condition:
+        return _error("'condition' is required")
+
+    try:
+        ws.filter(condition)
+        info = ws.inspect()
+        return JSONResponse({"filtered": True, "shape": info["shape"]})
+    except Exception as e:
+        return _error(f"{type(e).__name__}: {e}")
+
+
+async def sort_rows(request: Request) -> JSONResponse:
+    """Sort by column(s).
+
+    Body: {"by": "column_name", "descending": false}
+    """
+    ws = _get_workspace()
+    data = await _get_body(request)
+
+    by = data.get("by")
+    if not by:
+        return _error("'by' is required")
+
+    try:
+        ws.sort(by, descending=data.get("descending", False))
+        info = ws.inspect()
+        return JSONResponse({"sorted": True, "shape": info["shape"]})
+    except Exception as e:
+        return _error(f"{type(e).__name__}: {e}")
+
+
+async def select_columns(request: Request) -> JSONResponse:
+    """Select specific columns.
+
+    Body: {"columns": ["col1", "col2"]}
+    """
+    ws = _get_workspace()
+    data = await _get_body(request)
+
+    columns = data.get("columns")
+    if not columns:
+        return _error("'columns' is required")
+
+    try:
+        ws.select(*columns)
+        info = ws.inspect()
+        return JSONResponse({"selected": True, "shape": info["shape"], "columns": list(info["schema"].keys())})
+    except Exception as e:
+        return _error(f"{type(e).__name__}: {e}")
+
+
+async def sheets(request: Request) -> JSONResponse:
+    """List all sheets in the workspace."""
+    ws = _get_workspace()
+    current = ws._workbook.current_sheet_name
+    if not ws.sheet_names:
+        return JSONResponse({"sheets": [], "active": None})
+    try:
+        sheets_info = []
+        for name in ws.sheet_names:
+            ws.switch(name)
+            sheets_info.append({
+                "name": name,
+                "shape": ws.shape,
+                "columns": list(ws.df.columns) if ws.df is not None else [],
+            })
+        if current:
+            ws.switch(current)
+        return JSONResponse({"sheets": sheets_info, "active": current})
+    except Exception as e:
+        return _error(f"{type(e).__name__}: {e}")
+
+
+async def sample(request: Request) -> JSONResponse:
+    """Get a sample of rows.
+
+    Query params: ?n=10
+    """
+    ws = _get_workspace()
+    n = int(request.query_params.get("n", "10"))
+
+    try:
+        df = ws.sample(n)
+        if df is None:
+            return _error("No data loaded", status=404)
+        return JSONResponse({"rows": df.to_dicts(), "n": len(df)})
+    except Exception as e:
+        return _error(f"{type(e).__name__}: {e}")
+
+
+async def export_data(request: Request) -> JSONResponse:
+    """Export data to a file.
+
+    Body: {"path": "output.csv", "format": "csv"}
+    """
+    ws = _get_workspace()
+    data = await _get_body(request)
+
+    path = data.get("path")
+    if not path:
+        return _error("'path' is required")
+
+    try:
+        ws.export(path, format=data.get("format"))
+        return JSONResponse({"exported": path})
+    except Exception as e:
+        return _error(f"{type(e).__name__}: {e}")
+
+
+async def undo(request: Request) -> JSONResponse:
+    """Undo the last operation."""
+    ws = _get_workspace()
+    try:
+        ws.undo()
+        info = ws.inspect()
+        return JSONResponse({"undone": True, "shape": info["shape"]})
+    except Exception as e:
+        return _error(f"{type(e).__name__}: {e}")
+
+
+async def redo(request: Request) -> JSONResponse:
+    """Redo the last undone operation."""
+    ws = _get_workspace()
+    try:
+        ws.redo()
+        info = ws.inspect()
+        return JSONResponse({"redone": True, "shape": info["shape"]})
+    except Exception as e:
+        return _error(f"{type(e).__name__}: {e}")
+
+
+async def history(request: Request) -> JSONResponse:
+    """Get operation history."""
+    ws = _get_workspace()
+    try:
+        result = ws.history_summary()
+        return JSONResponse({"operations": result})
+    except Exception as e:
+        return _error(f"{type(e).__name__}: {e}")
+
+
+async def branch(request: Request) -> JSONResponse:
+    """Create a named branch.
+
+    Body: {"name": "experiment-1"}
+    """
+    ws = _get_workspace()
+    data = await _get_body(request)
+
+    name = data.get("name")
+    if not name:
+        return _error("'name' is required")
+
+    try:
+        ws.branch(name)
+        return JSONResponse({"branched": name})
+    except Exception as e:
+        return _error(f"{type(e).__name__}: {e}")
+
+
+async def switch(request: Request) -> JSONResponse:
+    """Switch to a different sheet.
+
+    Body: {"name": "sheet_name"}
+    """
+    ws = _get_workspace()
+    data = await _get_body(request)
+
+    name = data.get("name")
+    if not name:
+        return _error("'name' is required")
+
+    try:
+        ws.switch(name)
+        info = ws.inspect()
+        return JSONResponse({"switched": name, "shape": info["shape"]})
+    except Exception as e:
+        return _error(f"{type(e).__name__}: {e}")
+
+
+async def profile(request: Request) -> JSONResponse:
+    """Profile the active sheet (deep statistical scan)."""
+    ws = _get_workspace()
+    try:
+        result = ws.scan()
+        return JSONResponse(result)
+    except Exception as e:
+        return _error(f"{type(e).__name__}: {e}")
+
+
+async def describe(request: Request) -> JSONResponse:
+    """Get a natural-language description of the data."""
+    ws = _get_workspace()
+    try:
+        result = ws.describe()
+        return JSONResponse({"description": result})
+    except Exception as e:
+        return _error(f"{type(e).__name__}: {e}")
+
+
+async def recipe_run(request: Request) -> JSONResponse:
+    """Run a recipe on the active sheet.
+
+    Body: {"recipe": "clean-csv", "params": {"key": "value"}, "stop_on_error": true}
+    """
+    ws = _get_workspace()
+    data = await _get_body(request)
+
+    recipe_name = data.get("recipe")
+    if not recipe_name:
+        return _error("'recipe' is required")
+
+    try:
+        result = ws.run_recipe(
+            recipe_name,
+            params=data.get("params"),
+            stop_on_error=data.get("stop_on_error", True),
+        )
+        return JSONResponse(result)
+    except Exception as e:
+        return _error(f"{type(e).__name__}: {e}")
+
+
+async def recipe_list(request: Request) -> JSONResponse:
+    """List available recipes.
+
+    Query params: ?recipe_dir=/path/to/recipes
+    """
+    ws = _get_workspace()
+    recipe_dir = request.query_params.get("recipe_dir")
+    try:
+        result = ws.list_recipes(recipe_dir=recipe_dir)
+        return JSONResponse(result)
+    except Exception as e:
+        return _error(f"{type(e).__name__}: {e}")
+
+
+async def generate_code(request: Request) -> JSONResponse:
+    """Generate reproducible code from the operation history.
+
+    Query params: ?format=polars
+    """
+    ws = _get_workspace()
+    fmt = request.query_params.get("format", "polars")
+    try:
+        if fmt == "polars":
+            code = ws.generate_code()
+        else:
+            code = ws.generate_pipeline(format=fmt)
+        return JSONResponse({"code": code, "format": fmt})
+    except Exception as e:
+        return _error(f"{type(e).__name__}: {e}")
+
+
+async def validate_rules(request: Request) -> JSONResponse:
+    """Validate data against rules.
+
+    Body: {"rules": [{"name": "...", "check": "...", "severity": "error"}]}
+    """
+    ws = _get_workspace()
+    data = await _get_body(request)
+
+    rules = data.get("rules")
+    if not rules:
+        return _error("'rules' is required")
+
+    try:
+        result = ws.validate_rules(rules)
+        return JSONResponse(result)
+    except Exception as e:
+        return _error(f"{type(e).__name__}: {e}")
+
+
+async def schema(request: Request) -> JSONResponse:
+    """Get the schema of the active sheet."""
+    ws = _get_workspace()
+    try:
+        self_schema = ws.schema
+        return JSONResponse(self_schema)
+    except Exception as e:
+        return _error(f"{type(e).__name__}: {e}")
+
+
+# ---------------------------------------------------------------------------
+# App factory
+# ---------------------------------------------------------------------------
+
+
+def create_app() -> Starlette:
+    """Create the Starlette application with all routes."""
+    routes = [
+        Route("/api/health", health, methods=["GET"]),
+        Route("/api/load", load, methods=["POST"]),
+        Route("/api/inspect", inspect, methods=["GET"]),
+        Route("/api/transform", transform, methods=["POST"]),
+        Route("/api/query", query, methods=["POST"]),
+        Route("/api/filter", filter_rows, methods=["POST"]),
+        Route("/api/sort", sort_rows, methods=["POST"]),
+        Route("/api/select", select_columns, methods=["POST"]),
+        Route("/api/sheets", sheets, methods=["GET"]),
+        Route("/api/sample", sample, methods=["GET"]),
+        Route("/api/export", export_data, methods=["POST"]),
+        Route("/api/undo", undo, methods=["POST"]),
+        Route("/api/redo", redo, methods=["POST"]),
+        Route("/api/history", history, methods=["GET"]),
+        Route("/api/branch", branch, methods=["POST"]),
+        Route("/api/switch", switch, methods=["POST"]),
+        Route("/api/profile", profile, methods=["GET"]),
+        Route("/api/describe", describe, methods=["GET"]),
+        Route("/api/schema", schema, methods=["GET"]),
+        Route("/api/recipe/run", recipe_run, methods=["POST"]),
+        Route("/api/recipe/list", recipe_list, methods=["GET"]),
+        Route("/api/generate-code", generate_code, methods=["GET"]),
+        Route("/api/validate", validate_rules, methods=["POST"]),
+    ]
+
+    middleware = [
+        Middleware(
+            CORSMiddleware,
+            allow_origins=["*"],
+            allow_methods=["*"],
+            allow_headers=["*"],
+        ),
+    ]
+
+    return Starlette(routes=routes, middleware=middleware)
+
+
+def run_http_server(host: str = "127.0.0.1", port: int = 8421) -> None:
+    """Run the HTTP API server."""
+    import uvicorn
+
+    app = create_app()
+    uvicorn.run(app, host=host, port=port)

--- a/tests/test_http_api.py
+++ b/tests/test_http_api.py
@@ -1,0 +1,473 @@
+"""Tests for the HTTP REST API (sweet/http_api.py)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import polars as pl
+import pytest
+from starlette.testclient import TestClient
+
+from sweet.http_api import create_app, reset_workspace, _get_workspace
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    """Reset workspace before each test."""
+    reset_workspace()
+    yield
+    reset_workspace()
+
+
+@pytest.fixture
+def client():
+    app = create_app()
+    return TestClient(app)
+
+
+@pytest.fixture
+def csv_file(tmp_path: Path) -> Path:
+    df = pl.DataFrame({
+        "name": ["Alice", "Bob", "Charlie", "Diana"],
+        "age": [30, 25, 35, 28],
+        "city": ["NYC", "LA", "NYC", "Chicago"],
+    })
+    path = tmp_path / "test.csv"
+    df.write_csv(path)
+    return path
+
+
+@pytest.fixture
+def loaded_client(client, csv_file):
+    """Client with data already loaded."""
+    client.post("/api/load", json={"path": str(csv_file)})
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Health
+# ---------------------------------------------------------------------------
+
+
+class TestHealth:
+    def test_health(self, client):
+        resp = client.get("/api/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "ok"
+
+    def test_health_with_data(self, loaded_client):
+        resp = loaded_client.get("/api/health")
+        data = resp.json()
+        assert data["status"] == "ok"
+        assert len(data["sheets"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# Load
+# ---------------------------------------------------------------------------
+
+
+class TestLoad:
+    def test_load_csv(self, client, csv_file):
+        resp = client.post("/api/load", json={"path": str(csv_file)})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["loaded"] == str(csv_file)
+        assert data["shape"] == [4, 3]
+        assert "name" in data["columns"]
+
+    def test_load_with_name(self, client, csv_file):
+        resp = client.post("/api/load", json={"path": str(csv_file), "name": "my_data"})
+        assert resp.status_code == 200
+        assert resp.json()["shape"] == [4, 3]
+
+    def test_load_missing_path(self, client):
+        resp = client.post("/api/load", json={})
+        assert resp.status_code == 400
+        assert "path" in resp.json()["error"]
+
+    def test_load_nonexistent(self, client):
+        resp = client.post("/api/load", json={"path": "/nonexistent/file.csv"})
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Inspect
+# ---------------------------------------------------------------------------
+
+
+class TestInspect:
+    def test_inspect(self, loaded_client):
+        resp = loaded_client.get("/api/inspect")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["shape"] == [4, 3]
+        assert "name" in data["schema"]
+        assert len(data["sample"]) > 0
+
+    def test_inspect_no_data(self, client):
+        resp = client.get("/api/inspect")
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Transform
+# ---------------------------------------------------------------------------
+
+
+class TestTransform:
+    def test_transform(self, loaded_client):
+        resp = loaded_client.post(
+            "/api/transform",
+            json={"expr": "df.filter(pl.col('age') > 28)"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["transformed"] is True
+        assert data["shape"][0] == 2  # Alice (30) and Charlie (35)
+
+    def test_transform_missing_expr(self, loaded_client):
+        resp = loaded_client.post("/api/transform", json={})
+        assert resp.status_code == 400
+
+    def test_transform_bad_expr(self, loaded_client):
+        resp = loaded_client.post(
+            "/api/transform", json={"expr": "invalid_code!!!"}
+        )
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Filter
+# ---------------------------------------------------------------------------
+
+
+class TestFilter:
+    def test_filter(self, loaded_client):
+        resp = loaded_client.post(
+            "/api/filter", json={"condition": "pl.col('city') == 'NYC'"}
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["filtered"] is True
+        assert data["shape"][0] == 2
+
+    def test_filter_missing_condition(self, loaded_client):
+        resp = loaded_client.post("/api/filter", json={})
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Sort
+# ---------------------------------------------------------------------------
+
+
+class TestSort:
+    def test_sort(self, loaded_client):
+        resp = loaded_client.post("/api/sort", json={"by": "age"})
+        assert resp.status_code == 200
+        assert resp.json()["sorted"] is True
+
+    def test_sort_descending(self, loaded_client):
+        resp = loaded_client.post(
+            "/api/sort", json={"by": "age", "descending": True}
+        )
+        assert resp.status_code == 200
+
+    def test_sort_missing_by(self, loaded_client):
+        resp = loaded_client.post("/api/sort", json={})
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Select
+# ---------------------------------------------------------------------------
+
+
+class TestSelect:
+    def test_select(self, loaded_client):
+        resp = loaded_client.post("/api/select", json={"columns": ["name", "age"]})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["selected"] is True
+        assert data["shape"][1] == 2
+
+    def test_select_missing(self, loaded_client):
+        resp = loaded_client.post("/api/select", json={})
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Sheets
+# ---------------------------------------------------------------------------
+
+
+class TestSheets:
+    def test_sheets_empty(self, client):
+        resp = client.get("/api/sheets")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["sheets"] == []
+
+    def test_sheets_with_data(self, loaded_client):
+        resp = loaded_client.get("/api/sheets")
+        data = resp.json()
+        assert len(data["sheets"]) == 1
+        assert data["sheets"][0]["shape"] == [4, 3]
+
+
+# ---------------------------------------------------------------------------
+# Sample
+# ---------------------------------------------------------------------------
+
+
+class TestSample:
+    def test_sample(self, loaded_client):
+        resp = loaded_client.get("/api/sample?n=2")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["rows"]) == 2
+
+    def test_sample_default(self, loaded_client):
+        resp = loaded_client.get("/api/sample")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["rows"]) == 4  # only 4 rows, less than default 10
+
+
+# ---------------------------------------------------------------------------
+# Export
+# ---------------------------------------------------------------------------
+
+
+class TestExport:
+    def test_export_csv(self, loaded_client, tmp_path):
+        out = tmp_path / "output.csv"
+        resp = loaded_client.post("/api/export", json={"path": str(out)})
+        assert resp.status_code == 200
+        assert resp.json()["exported"] == str(out)
+        assert out.exists()
+        df = pl.read_csv(out)
+        assert len(df) == 4
+
+    def test_export_missing_path(self, loaded_client):
+        resp = loaded_client.post("/api/export", json={})
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Undo / Redo
+# ---------------------------------------------------------------------------
+
+
+class TestUndoRedo:
+    def test_undo(self, loaded_client):
+        # Transform then undo
+        loaded_client.post(
+            "/api/transform", json={"expr": "df.filter(pl.col('age') > 30)"}
+        )
+        resp = loaded_client.post("/api/undo")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["undone"] is True
+        assert data["shape"][0] == 4  # back to original
+
+    def test_redo(self, loaded_client):
+        loaded_client.post(
+            "/api/transform", json={"expr": "df.filter(pl.col('age') > 30)"}
+        )
+        loaded_client.post("/api/undo")
+        resp = loaded_client.post("/api/redo")
+        assert resp.status_code == 200
+        assert resp.json()["redone"] is True
+
+
+# ---------------------------------------------------------------------------
+# History
+# ---------------------------------------------------------------------------
+
+
+class TestHistory:
+    def test_history(self, loaded_client):
+        loaded_client.post(
+            "/api/transform", json={"expr": "df.filter(pl.col('age') > 28)"}
+        )
+        resp = loaded_client.get("/api/history")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["operations"]) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Branch / Switch
+# ---------------------------------------------------------------------------
+
+
+class TestBranchSwitch:
+    def test_branch(self, loaded_client):
+        resp = loaded_client.post("/api/branch", json={"name": "experiment"})
+        assert resp.status_code == 200
+        assert resp.json()["branched"] == "experiment"
+
+    def test_switch(self, loaded_client):
+        loaded_client.post("/api/branch", json={"name": "exp"})
+        resp = loaded_client.post("/api/switch", json={"name": "exp"})
+        assert resp.status_code == 200
+        assert resp.json()["switched"] == "exp"
+
+    def test_branch_missing_name(self, loaded_client):
+        resp = loaded_client.post("/api/branch", json={})
+        assert resp.status_code == 400
+
+    def test_switch_missing_name(self, loaded_client):
+        resp = loaded_client.post("/api/switch", json={})
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Describe
+# ---------------------------------------------------------------------------
+
+
+class TestDescribe:
+    def test_describe(self, loaded_client):
+        resp = loaded_client.get("/api/describe")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "description" in data
+        assert len(data["description"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+class TestSchema:
+    def test_schema(self, loaded_client):
+        resp = loaded_client.get("/api/schema")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "name" in data  # column name in schema dict
+        assert "age" in data
+
+
+# ---------------------------------------------------------------------------
+# Recipes
+# ---------------------------------------------------------------------------
+
+
+class TestRecipes:
+    def test_recipe_list(self, loaded_client):
+        resp = loaded_client.get("/api/recipe/list")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) >= 3  # built-in recipes
+        names = [r["name"] for r in data]
+        assert "clean-csv" in names
+
+    def test_recipe_run(self, loaded_client):
+        resp = loaded_client.post(
+            "/api/recipe/run", json={"recipe": "clean-csv"}
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+        assert data["steps_completed"] == 3
+
+    def test_recipe_run_with_params(self, loaded_client):
+        resp = loaded_client.post(
+            "/api/recipe/run",
+            json={"recipe": "quick-profile", "params": {"sample_size": 2}},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["success"] is True
+
+    def test_recipe_run_missing(self, loaded_client):
+        resp = loaded_client.post("/api/recipe/run", json={})
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Validate
+# ---------------------------------------------------------------------------
+
+
+class TestValidate:
+    def test_validate(self, loaded_client):
+        resp = loaded_client.post(
+            "/api/validate",
+            json={
+                "rules": [
+                    {"name": "age_positive", "check": "col('age') > 0", "severity": "error"}
+                ]
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "rules_checked" in data
+
+    def test_validate_missing_rules(self, loaded_client):
+        resp = loaded_client.post("/api/validate", json={})
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Generate Code
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateCode:
+    def test_generate_code(self, loaded_client):
+        loaded_client.post(
+            "/api/transform", json={"expr": "df.filter(pl.col('age') > 28)"}
+        )
+        resp = loaded_client.get("/api/generate-code")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "code" in data
+        assert data["format"] == "polars"
+
+
+# ---------------------------------------------------------------------------
+# Query (SQL)
+# ---------------------------------------------------------------------------
+
+
+class TestQuery:
+    def test_query(self, loaded_client):
+        resp = loaded_client.post(
+            "/api/query",
+            json={"sql": "SELECT name, age FROM test WHERE age > 28"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["queried"] is True
+
+    def test_query_missing_sql(self, loaded_client):
+        resp = loaded_client.post("/api/query", json={})
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# CORS
+# ---------------------------------------------------------------------------
+
+
+class TestCORS:
+    def test_cors_headers(self, client):
+        resp = client.options(
+            "/api/health",
+            headers={
+                "Origin": "http://example.com",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        assert resp.headers.get("access-control-allow-origin") == "*"

--- a/tests/test_http_api.py
+++ b/tests/test_http_api.py
@@ -7,9 +7,11 @@ from pathlib import Path
 
 import polars as pl
 import pytest
-from starlette.testclient import TestClient
 
-from sweet.http_api import create_app, reset_workspace, _get_workspace
+starlette = pytest.importorskip("starlette", reason="starlette not installed")
+from starlette.testclient import TestClient  # noqa: E402
+
+from sweet.http_api import create_app, reset_workspace, _get_workspace  # noqa: E402
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This PR introduces support for running the Sweet server as an HTTP REST API, in addition to the existing MCP protocol. It adds new dependencies for HTTP support, updates CLI options to allow selecting the protocol and configuring the server address, and implements the HTTP server startup logic.